### PR TITLE
Phase B: upsell reports — by-teacher, by-product, teacher detail tab

### DIFF
--- a/app/Services/Upsell/UpsellPaidOrdersQuery.php
+++ b/app/Services/Upsell/UpsellPaidOrdersQuery.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Upsell;
+
+use App\Models\FunnelOrder;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as SupportCollection;
+
+/**
+ * Shared query for paid upsell funnel orders.
+ *
+ * Single source of truth used by every Phase B upsell report
+ * (dashboard by-teacher, dashboard by-product, teacher upsell tab).
+ *
+ * Filters honoured:
+ *  - Class session has a non-null `upsell_funnel_ids` (i.e. an upsell was assigned).
+ *  - Class session `session_date` between the optional from/to inclusive.
+ *  - Optional: session's `upsell_funnel_ids` contains the given funnel id.
+ *  - Optional: session's `upsell_pic_user_ids` contains the given user id.
+ *  - Linked `product_order.payment_status` is `paid`.
+ */
+class UpsellPaidOrdersQuery
+{
+    private ?string $from = null;
+
+    private ?string $to = null;
+
+    private ?int $funnelId = null;
+
+    private ?int $picId = null;
+
+    public function forDateRange(?string $from, ?string $to): self
+    {
+        $this->from = $from ?: null;
+        $this->to = $to ?: null;
+
+        return $this;
+    }
+
+    public function forFunnelId(?int $funnelId): self
+    {
+        $this->funnelId = $funnelId ?: null;
+
+        return $this;
+    }
+
+    public function forPicId(?int $picId): self
+    {
+        $this->picId = $picId ?: null;
+
+        return $this;
+    }
+
+    /**
+     * The single source of truth. Every aggregate method funnels through this.
+     */
+    public function baseQuery(): Builder
+    {
+        return FunnelOrder::query()
+            ->whereHas('productOrder', fn ($q) => $q->where('payment_status', 'paid'))
+            ->whereHas('classSession', function ($q) {
+                $q->whereNotNull('upsell_funnel_ids');
+
+                if ($this->from) {
+                    $q->whereDate('session_date', '>=', $this->from);
+                }
+
+                if ($this->to) {
+                    $q->whereDate('session_date', '<=', $this->to);
+                }
+
+                if ($this->funnelId) {
+                    $q->whereJsonContains('upsell_funnel_ids', $this->funnelId);
+                }
+
+                if ($this->picId) {
+                    $q->whereJsonContains('upsell_pic_user_ids', $this->picId);
+                }
+            });
+    }
+
+    /**
+     * Eager-loaded collection of paid funnel orders.
+     */
+    public function get(): Collection
+    {
+        return $this->baseQuery()
+            ->with(['classSession', 'productOrder.items'])
+            ->get();
+    }
+
+    /**
+     * Aggregate paid revenue + commission by upsell teacher.
+     *
+     * Sessions may list multiple upsell teachers in `upsell_teacher_ids` (JSON array).
+     * When a session has N teachers the per-order revenue and commission are split
+     * equally across each teacher. Sessions with no upsell teachers are skipped.
+     *
+     * @return SupportCollection<int, array{
+     *     teacher_id: int,
+     *     teacher_name: string|null,
+     *     sessions_count: int,
+     *     paid_orders: int,
+     *     paid_revenue: float,
+     *     commission_earned: float,
+     *     top_products: SupportCollection<int, array{product_id: int|null, product_name: string, units: int, revenue: float}>,
+     * }>
+     */
+    public function byTeacher(): SupportCollection
+    {
+        $orders = $this->baseQuery()
+            ->with(['classSession', 'productOrder.items'])
+            ->get();
+
+        $byTeacher = [];
+
+        foreach ($orders as $order) {
+            $session = $order->classSession;
+            if (! $session) {
+                continue;
+            }
+
+            $teacherIds = $session->upsell_teacher_ids ?? [];
+            if (empty($teacherIds)) {
+                continue;
+            }
+
+            $split = count($teacherIds);
+            $orderRevenue = (float) $order->funnel_revenue;
+            $rate = (float) ($session->upsell_teacher_commission_rate ?? 0);
+            $orderCommission = $orderRevenue * ($rate / 100);
+
+            $teacherRevenueShare = $orderRevenue / $split;
+            $teacherCommissionShare = $orderCommission / $split;
+
+            foreach ($teacherIds as $teacherId) {
+                if (! isset($byTeacher[$teacherId])) {
+                    $byTeacher[$teacherId] = [
+                        'teacher_id' => (int) $teacherId,
+                        'session_ids' => [],
+                        'paid_orders' => 0,
+                        'paid_revenue' => 0.0,
+                        'commission_earned' => 0.0,
+                        'product_lines' => [],
+                    ];
+                }
+
+                $byTeacher[$teacherId]['session_ids'][$session->id] = true;
+                $byTeacher[$teacherId]['paid_orders']++;
+                $byTeacher[$teacherId]['paid_revenue'] += $teacherRevenueShare;
+                $byTeacher[$teacherId]['commission_earned'] += $teacherCommissionShare;
+
+                foreach ($order->productOrder?->items ?? [] as $item) {
+                    $pid = $item->product_id;
+                    if (! $pid) {
+                        continue;
+                    }
+
+                    if (! isset($byTeacher[$teacherId]['product_lines'][$pid])) {
+                        $byTeacher[$teacherId]['product_lines'][$pid] = [
+                            'product_id' => $pid,
+                            'product_name' => $item->product_name ?? 'Unknown',
+                            'units' => 0,
+                            'revenue' => 0.0,
+                        ];
+                    }
+
+                    $byTeacher[$teacherId]['product_lines'][$pid]['units'] += (int) $item->quantity_ordered;
+                    $byTeacher[$teacherId]['product_lines'][$pid]['revenue'] += ((float) $item->total_price) / $split;
+                }
+            }
+        }
+
+        if (empty($byTeacher)) {
+            return collect();
+        }
+
+        $users = User::whereIn('id', array_keys($byTeacher))->get()->keyBy('id');
+
+        return collect($byTeacher)
+            ->map(function (array $row) use ($users): array {
+                $user = $users->get($row['teacher_id']);
+
+                $topProducts = collect($row['product_lines'])
+                    ->sortByDesc('revenue')
+                    ->take(5)
+                    ->values();
+
+                return [
+                    'teacher_id' => $row['teacher_id'],
+                    'teacher_name' => $user?->name,
+                    'sessions_count' => count($row['session_ids']),
+                    'paid_orders' => $row['paid_orders'],
+                    'paid_revenue' => round($row['paid_revenue'], 2),
+                    'commission_earned' => round($row['commission_earned'], 2),
+                    'top_products' => $topProducts,
+                ];
+            })
+            ->sortByDesc('commission_earned')
+            ->values();
+    }
+
+    /**
+     * Aggregate paid revenue + units by product, tagged with the funnel order
+     * line type (`main`, `bump`, `upsell`, `downsell`) inferred from
+     * `funnel_orders.order_type`.
+     *
+     * Note: `product_order_items` has no explicit line_type column. The line
+     * type is derived from the parent FunnelOrder's `order_type`. In this app's
+     * data model each FunnelOrder maps 1:1 to a ProductOrder, so items inherit
+     * their parent funnel order's type cleanly.
+     *
+     * @return SupportCollection<int, array{
+     *     product_id: int,
+     *     product_name: string,
+     *     line_type: string,
+     *     funnel_ids: SupportCollection,
+     *     units: int,
+     *     revenue: float,
+     * }>
+     */
+    public function byProduct(): SupportCollection
+    {
+        $orders = $this->baseQuery()
+            ->with('productOrder.items')
+            ->get();
+
+        $lines = collect();
+
+        foreach ($orders as $order) {
+            $lineType = $order->order_type ?: 'main';
+
+            foreach ($order->productOrder?->items ?? [] as $item) {
+                if (! $item->product_id) {
+                    continue;
+                }
+
+                $lines->push([
+                    'product_id' => (int) $item->product_id,
+                    'product_name' => $item->product_name ?? 'Unknown',
+                    'line_type' => $lineType,
+                    'funnel_id' => $order->funnel_id,
+                    'units' => (int) $item->quantity_ordered,
+                    'revenue' => (float) $item->total_price,
+                ]);
+            }
+        }
+
+        return $lines
+            ->groupBy('product_id')
+            ->map(function (SupportCollection $rows, $productId): array {
+                return [
+                    'product_id' => (int) $productId,
+                    'product_name' => $rows->first()['product_name'],
+                    'line_type' => $rows->first()['line_type'],
+                    'funnel_ids' => $rows->pluck('funnel_id')->filter()->unique()->values(),
+                    'units' => (int) $rows->sum('units'),
+                    'revenue' => round((float) $rows->sum('revenue'), 2),
+                ];
+            })
+            ->sortByDesc('revenue')
+            ->values();
+    }
+}

--- a/resources/views/livewire/admin/teacher-show.blade.php
+++ b/resources/views/livewire/admin/teacher-show.blade.php
@@ -1,22 +1,72 @@
 <?php
 
+use App\Models\ClassSession;
 use App\Models\Teacher;
+use App\Services\Upsell\UpsellPaidOrdersQuery;
 use Livewire\Volt\Component;
 
-new class extends Component {
+new class extends Component
+{
     public Teacher $teacher;
+
+    public string $upsellDateFrom = '';
+
+    public string $upsellDateTo = '';
 
     public function mount(Teacher $teacher): void
     {
         $this->teacher = $teacher->load(['user', 'courses.feeSettings', 'courses.enrollments']);
+        $this->upsellDateFrom = now()->subDays(90)->toDateString();
+        $this->upsellDateTo = now()->toDateString();
     }
 
     public function deleteTeacher(): void
     {
         $this->teacher->delete();
-        
+
         session()->flash('success', 'Teacher deleted successfully.');
         $this->redirect(route('teachers.index'));
+    }
+
+    public function getUpsellStatsProperty(): array
+    {
+        $default = [
+            'sessions_count' => 0,
+            'paid_orders' => 0,
+            'paid_revenue' => 0,
+            'commission_earned' => 0,
+            'top_products' => collect(),
+        ];
+
+        if (! $this->teacher->user_id) {
+            return $default;
+        }
+
+        $row = app(UpsellPaidOrdersQuery::class)
+            ->forDateRange($this->upsellDateFrom ?: null, $this->upsellDateTo ?: null)
+            ->byTeacher()
+            ->firstWhere('teacher_id', $this->teacher->user_id);
+
+        return $row ?? $default;
+    }
+
+    public function getUpsellSessionsProperty()
+    {
+        if (! $this->teacher->user_id) {
+            return collect();
+        }
+
+        return ClassSession::query()
+            ->whereJsonContains('upsell_teacher_ids', $this->teacher->user_id)
+            ->when($this->upsellDateFrom, fn ($q) => $q->whereDate('session_date', '>=', $this->upsellDateFrom))
+            ->when($this->upsellDateTo, fn ($q) => $q->whereDate('session_date', '<=', $this->upsellDateTo))
+            ->whereHas('funnelOrders', fn ($q) => $q->whereHas('productOrder', fn ($qq) => $qq->where('payment_status', 'paid')))
+            ->withCount(['funnelOrders as paid_orders_count' => fn ($q) => $q->whereHas('productOrder', fn ($qq) => $qq->where('payment_status', 'paid'))])
+            ->withSum(['funnelOrders as paid_revenue_sum' => fn ($q) => $q->whereHas('productOrder', fn ($qq) => $qq->where('payment_status', 'paid'))], 'funnel_revenue')
+            ->with(['class', 'class.course'])
+            ->orderByDesc('session_date')
+            ->limit(50)
+            ->get();
     }
 };
 ?>
@@ -194,6 +244,74 @@ new class extends Component {
                 <flux:text class="text-sm text-gray-500 dark:text-gray-400">This teacher hasn't been assigned to any courses yet.</flux:text>
             </div>
         @endif
+    </div>
+
+    <!-- Upsell Performance -->
+    <div class="bg-white dark:bg-zinc-800 shadow rounded-lg">
+        <div class="px-6 py-4 border-b border-gray-200 dark:border-zinc-700">
+            <div class="flex items-center justify-between gap-4 flex-wrap">
+                <div>
+                    <flux:heading size="lg">Upsell Performance</flux:heading>
+                    <flux:text class="mt-1">Paid orders only. Multi-teacher session revenue is split equally.</flux:text>
+                </div>
+                <div class="flex gap-2 items-end">
+                    <flux:input type="date" wire:model.live="upsellDateFrom" size="sm" label="From" />
+                    <flux:input type="date" wire:model.live="upsellDateTo" size="sm" label="To" />
+                </div>
+            </div>
+        </div>
+        <div class="p-6">
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div class="border rounded p-4 dark:border-zinc-700">
+                    <div class="text-xs text-gray-600 dark:text-gray-400 uppercase">Sessions with Upsell</div>
+                    <div class="text-2xl font-bold mt-1">{{ $this->upsellStats['sessions_count'] }}</div>
+                </div>
+                <div class="border rounded p-4 dark:border-zinc-700">
+                    <div class="text-xs text-gray-600 dark:text-gray-400 uppercase">Paid Orders</div>
+                    <div class="text-2xl font-bold mt-1">{{ $this->upsellStats['paid_orders'] }}</div>
+                </div>
+                <div class="border rounded p-4 dark:border-zinc-700">
+                    <div class="text-xs text-gray-600 dark:text-gray-400 uppercase">Paid Revenue</div>
+                    <div class="text-2xl font-bold mt-1">RM {{ number_format((float) $this->upsellStats['paid_revenue'], 2) }}</div>
+                </div>
+                <div class="border rounded p-4 dark:border-zinc-700">
+                    <div class="text-xs text-gray-600 dark:text-gray-400 uppercase">Commission Earned</div>
+                    <div class="text-2xl font-bold mt-1 text-amber-600">RM {{ number_format((float) $this->upsellStats['commission_earned'], 2) }}</div>
+                </div>
+            </div>
+
+            <div class="mt-6">
+                <flux:heading size="md" class="mb-2">Upsell Sessions ({{ $this->upsellSessions->count() }})</flux:heading>
+                @if($this->upsellSessions->isEmpty())
+                    <flux:text class="text-gray-500">No upsell sessions in selected period.</flux:text>
+                @else
+                <div class="overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b dark:border-zinc-700">
+                                <th class="text-left py-2 px-3">Date</th>
+                                <th class="text-left py-2 px-3">Class</th>
+                                <th class="text-right py-2 px-3">Paid Orders</th>
+                                <th class="text-right py-2 px-3">Paid Revenue</th>
+                                <th class="text-right py-2 px-3">Commission Rate</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($this->upsellSessions as $session)
+                            <tr wire:key="session-{{ $session->id }}" class="border-b dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700/40">
+                                <td class="py-2 px-3">{{ $session->session_date?->format('Y-m-d') }}</td>
+                                <td class="py-2 px-3">{{ $session->class?->title ?? '—' }}</td>
+                                <td class="text-right py-2 px-3">{{ $session->paid_orders_count }}</td>
+                                <td class="text-right py-2 px-3">RM {{ number_format((float) ($session->paid_revenue_sum ?? 0), 2) }}</td>
+                                <td class="text-right py-2 px-3">{{ number_format((float) $session->upsell_teacher_commission_rate, 2) }}%</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                @endif
+            </div>
+        </div>
     </div>
 
     <!-- Danger Zone -->

--- a/resources/views/livewire/admin/upsell-dashboard.blade.php
+++ b/resources/views/livewire/admin/upsell-dashboard.blade.php
@@ -144,6 +144,28 @@ new class extends Component {
             ->get();
     }
 
+    public function getByTeacherProperty(): \Illuminate\Support\Collection
+    {
+        return app(\App\Services\Upsell\UpsellPaidOrdersQuery::class)
+            ->forDateRange($this->dateFrom ?: null, $this->dateTo ?: null)
+            ->forFunnelId($this->filterFunnelId ? (int) $this->filterFunnelId : null)
+            ->forPicId($this->filterPicId ? (int) $this->filterPicId : null)
+            ->byTeacher();
+    }
+
+    public function getTeacherIdMapProperty(): array
+    {
+        $userIds = $this->byTeacher->pluck('teacher_id')->all();
+
+        if (empty($userIds)) {
+            return [];
+        }
+
+        return \App\Models\Teacher::whereIn('user_id', $userIds)
+            ->pluck('id', 'user_id')
+            ->all();
+    }
+
     public function getPicBreakdownProperty(): \Illuminate\Support\Collection
     {
         $sessions = ClassSession::query()
@@ -440,5 +462,65 @@ new class extends Component {
                 </tbody>
             </table>
         </div>
+    </div>
+
+    {{-- Teacher Performance --}}
+    @php $teacherIdMap = $this->teacherIdMap; @endphp
+    <div class="rounded-lg border border-zinc-200 dark:border-zinc-700 mt-6">
+        <div class="border-b border-zinc-200 dark:border-zinc-700 px-5 py-3">
+            <h3 class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Performance by Teacher</h3>
+            <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">Commission earned by each upsell teacher (paid orders only)</p>
+        </div>
+        @if($this->byTeacher->isEmpty())
+            <div class="py-8 text-center">
+                <p class="text-xs text-zinc-400">No teacher data in selected period</p>
+            </div>
+        @else
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800">
+                        <th class="text-left py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Teacher</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Sessions</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Paid Orders</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Paid Revenue</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Commission Earned</th>
+                        <th class="text-left py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Top Products</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white dark:bg-zinc-900 divide-y divide-zinc-100 dark:divide-zinc-800">
+                    @foreach($this->byTeacher as $row)
+                        <tr wire:key="teacher-{{ $row['teacher_id'] }}" class="hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors">
+                            <td class="py-2.5 px-4">
+                                <div class="flex items-center gap-2">
+                                    <span class="flex items-center justify-center w-7 h-7 rounded-full bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400 text-xs font-semibold shrink-0">
+                                        {{ strtoupper(substr($row['teacher_name'] ?? '?', 0, 1)) }}
+                                    </span>
+                                    @if(isset($teacherIdMap[$row['teacher_id']]))
+                                        <a href="{{ route('teachers.show', $teacherIdMap[$row['teacher_id']]) }}" class="text-sm font-medium text-blue-600 hover:underline dark:text-blue-400" wire:navigate>
+                                            {{ $row['teacher_name'] ?? '—' }}
+                                        </a>
+                                    @else
+                                        <span class="text-sm font-medium text-zinc-900 dark:text-zinc-100">{{ $row['teacher_name'] ?? '—' }}</span>
+                                    @endif
+                                </div>
+                            </td>
+                            <td class="py-2.5 px-3 text-right text-sm text-zinc-600 dark:text-zinc-400 tabular-nums">{{ $row['sessions_count'] }}</td>
+                            <td class="py-2.5 px-3 text-right text-sm text-zinc-600 dark:text-zinc-400 tabular-nums">{{ $row['paid_orders'] }}</td>
+                            <td class="py-2.5 px-3 text-right text-sm text-zinc-600 dark:text-zinc-400 tabular-nums whitespace-nowrap">RM {{ number_format($row['paid_revenue'], 2) }}</td>
+                            <td class="py-2.5 px-3 text-right text-sm font-semibold text-amber-600 dark:text-amber-400 tabular-nums whitespace-nowrap">RM {{ number_format($row['commission_earned'], 2) }}</td>
+                            <td class="py-2.5 px-4 text-xs text-zinc-600 dark:text-zinc-400">
+                                @forelse($row['top_products']->take(3) as $product)
+                                    <div class="truncate">{{ $product['product_name'] }} — RM {{ number_format($product['revenue'], 2) }}</div>
+                                @empty
+                                    <span class="text-zinc-400">—</span>
+                                @endforelse
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        @endif
     </div>
 </div>

--- a/resources/views/livewire/admin/upsell-dashboard.blade.php
+++ b/resources/views/livewire/admin/upsell-dashboard.blade.php
@@ -166,6 +166,26 @@ new class extends Component {
             ->all();
     }
 
+    public function getByProductProperty(): \Illuminate\Support\Collection
+    {
+        return app(\App\Services\Upsell\UpsellPaidOrdersQuery::class)
+            ->forDateRange($this->dateFrom ?: null, $this->dateTo ?: null)
+            ->forFunnelId($this->filterFunnelId ? (int) $this->filterFunnelId : null)
+            ->forPicId($this->filterPicId ? (int) $this->filterPicId : null)
+            ->byProduct();
+    }
+
+    public function lineTypeBadgeColor(string $type): string
+    {
+        return match ($type) {
+            'main' => 'blue',
+            'bump' => 'amber',
+            'upsell' => 'green',
+            'downsell' => 'zinc',
+            default => 'zinc',
+        };
+    }
+
     public function getPicBreakdownProperty(): \Illuminate\Support\Collection
     {
         $sessions = ClassSession::query()
@@ -516,6 +536,50 @@ new class extends Component {
                                     <span class="text-zinc-400">—</span>
                                 @endforelse
                             </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        @endif
+    </div>
+
+    {{-- Product Performance --}}
+    <div class="rounded-lg border border-zinc-200 dark:border-zinc-700 mt-6">
+        <div class="border-b border-zinc-200 dark:border-zinc-700 px-5 py-3">
+            <h3 class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Performance by Product</h3>
+            <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">Products sold through funnels (paid orders only, line-level)</p>
+        </div>
+        @if($this->byProduct->isEmpty())
+            <div class="py-8 text-center">
+                <p class="text-xs text-zinc-400">No product data in selected period</p>
+            </div>
+        @else
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800">
+                        <th class="text-left py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Product</th>
+                        <th class="text-left py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Type</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Funnels</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Units</th>
+                        <th class="text-right py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Revenue</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white dark:bg-zinc-900 divide-y divide-zinc-100 dark:divide-zinc-800">
+                    @foreach($this->byProduct as $row)
+                        <tr wire:key="product-{{ $row['product_id'] }}-{{ $row['line_type'] }}" class="hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors">
+                            <td class="py-2.5 px-4">
+                                <p class="text-sm font-medium text-zinc-900 dark:text-zinc-100">{{ $row['product_name'] }}</p>
+                            </td>
+                            <td class="py-2.5 px-3">
+                                <flux:badge :color="$this->lineTypeBadgeColor($row['line_type'])" size="sm">
+                                    {{ ucfirst($row['line_type']) }}
+                                </flux:badge>
+                            </td>
+                            <td class="py-2.5 px-3 text-right text-sm text-zinc-600 dark:text-zinc-400 tabular-nums">{{ $row['funnel_ids']->count() }}</td>
+                            <td class="py-2.5 px-3 text-right text-sm text-zinc-600 dark:text-zinc-400 tabular-nums">{{ $row['units'] }}</td>
+                            <td class="py-2.5 px-4 text-right text-sm font-semibold text-zinc-900 dark:text-zinc-100 tabular-nums whitespace-nowrap">RM {{ number_format($row['revenue'], 2) }}</td>
                         </tr>
                     @endforeach
                 </tbody>

--- a/tests/Feature/Livewire/Admin/TeacherShowUpsellTabTest.php
+++ b/tests/Feature/Livewire/Admin/TeacherShowUpsellTabTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ClassSession;
+use App\Models\FunnelOrder;
+use App\Models\ProductOrder;
+use App\Models\Teacher;
+use App\Models\User;
+use Livewire\Volt\Volt;
+
+it('shows upsell stats for the teacher', function () {
+    $admin = User::factory()->admin()->create();
+    $teacherUser = User::factory()->create();
+    $teacher = Teacher::factory()->create(['user_id' => $teacherUser->id]);
+
+    $session = ClassSession::factory()->create([
+        'session_date' => now()->subDays(5),
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacherUser->id],
+        'upsell_teacher_commission_rate' => 15,
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $this->actingAs($admin);
+    Volt::test('admin.teacher-show', ['teacher' => $teacher])
+        ->assertSee('Upsell Performance')
+        ->assertSee('1,000.00')  // paid revenue
+        ->assertSee('150.00');   // commission (15% of 1000)
+});
+
+it('reacts to date range changes', function () {
+    $admin = User::factory()->admin()->create();
+    $teacherUser = User::factory()->create();
+    $teacher = Teacher::factory()->create(['user_id' => $teacherUser->id]);
+
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacherUser->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-02-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 500,
+    ]);
+
+    $this->actingAs($admin);
+
+    // Outside range
+    Volt::test('admin.teacher-show', ['teacher' => $teacher])
+        ->set('upsellDateFrom', '2026-05-01')
+        ->set('upsellDateTo', '2026-05-31')
+        ->assertDontSee('500.00');
+
+    // Inside range
+    Volt::test('admin.teacher-show', ['teacher' => $teacher])
+        ->set('upsellDateFrom', '2026-02-01')
+        ->set('upsellDateTo', '2026-02-28')
+        ->assertSee('500.00');
+});
+
+it('shows empty state when teacher has no upsell sessions', function () {
+    $admin = User::factory()->admin()->create();
+    $teacherUser = User::factory()->create();
+    $teacher = Teacher::factory()->create(['user_id' => $teacherUser->id]);
+
+    $this->actingAs($admin);
+    Volt::test('admin.teacher-show', ['teacher' => $teacher])
+        ->assertSee('No upsell sessions in selected period');
+});

--- a/tests/Feature/Livewire/Admin/UpsellDashboardProductBreakdownTest.php
+++ b/tests/Feature/Livewire/Admin/UpsellDashboardProductBreakdownTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ClassSession;
+use App\Models\FunnelOrder;
+use App\Models\Product;
+use App\Models\ProductOrder;
+use App\Models\ProductOrderItem;
+use App\Models\User;
+use Livewire\Volt\Volt;
+
+it('renders by-product section listing paid products', function () {
+    $admin = User::factory()->admin()->create();
+    $teacher = User::factory()->create();
+
+    $session = ClassSession::factory()->create([
+        'session_date' => now()->startOfMonth()->addDays(2),
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+    ]);
+
+    $product = Product::factory()->create(['name' => 'Stellar Course']);
+
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    ProductOrderItem::factory()->create([
+        'order_id' => $paid->id,
+        'product_id' => $product->id,
+        'product_name' => 'Stellar Course',
+        'quantity_ordered' => 1,
+        'total_price' => 500,
+    ]);
+
+    FunnelOrder::factory()->create([
+        'funnel_id' => 1,
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'order_type' => 'main',
+        'funnel_revenue' => 500,
+    ]);
+
+    $this->actingAs($admin);
+
+    Volt::test('admin.upsell-dashboard')
+        ->assertSee('Performance by Product')
+        ->assertSee('Stellar Course')
+        ->assertSee('Main') // ucfirst of line_type
+        ->assertSee('500.00');
+});
+
+it('shows products sorted by revenue descending with different line types', function () {
+    $admin = User::factory()->admin()->create();
+    $teacher = User::factory()->create();
+
+    $session = ClassSession::factory()->create([
+        'session_date' => now()->startOfMonth()->addDays(2),
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+    ]);
+
+    $mainProduct = Product::factory()->create(['name' => 'AAA Main Item']);
+    $bumpProduct = Product::factory()->create(['name' => 'BBB Bump Item']);
+
+    $mainOrder = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    ProductOrderItem::factory()->create([
+        'order_id' => $mainOrder->id,
+        'product_id' => $mainProduct->id,
+        'product_name' => 'AAA Main Item',
+        'quantity_ordered' => 1,
+        'total_price' => 1000,
+    ]);
+
+    $bumpOrder = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    ProductOrderItem::factory()->create([
+        'order_id' => $bumpOrder->id,
+        'product_id' => $bumpProduct->id,
+        'product_name' => 'BBB Bump Item',
+        'quantity_ordered' => 1,
+        'total_price' => 200,
+    ]);
+
+    FunnelOrder::factory()->create([
+        'funnel_id' => 1,
+        'class_session_id' => $session->id,
+        'product_order_id' => $mainOrder->id,
+        'order_type' => 'main',
+        'funnel_revenue' => 1000,
+    ]);
+    FunnelOrder::factory()->create([
+        'funnel_id' => 1,
+        'class_session_id' => $session->id,
+        'product_order_id' => $bumpOrder->id,
+        'order_type' => 'bump',
+        'funnel_revenue' => 200,
+    ]);
+
+    $this->actingAs($admin);
+
+    Volt::test('admin.upsell-dashboard')
+        ->assertSeeInOrder(['AAA Main Item', 'BBB Bump Item'])
+        ->assertSee('Bump');
+});
+
+it('shows empty state when no products', function () {
+    $admin = User::factory()->admin()->create();
+    $this->actingAs($admin);
+
+    Volt::test('admin.upsell-dashboard')
+        ->assertSee('No product data in selected period');
+});

--- a/tests/Feature/Livewire/Admin/UpsellDashboardTeacherBreakdownTest.php
+++ b/tests/Feature/Livewire/Admin/UpsellDashboardTeacherBreakdownTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ClassSession;
+use App\Models\FunnelOrder;
+use App\Models\ProductOrder;
+use App\Models\User;
+use Livewire\Volt\Volt;
+
+it('renders by-teacher section with paid revenue and commission', function () {
+    $admin = User::factory()->admin()->create();
+    $teacher = User::factory()->create(['name' => 'Top Teacher']);
+
+    $session = ClassSession::factory()->create([
+        'session_date' => now()->startOfMonth()->addDays(2),
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 15,
+    ]);
+
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $this->actingAs($admin);
+
+    Volt::test('admin.upsell-dashboard')
+        ->assertSee('Performance by Teacher')
+        ->assertSee('Top Teacher')
+        ->assertSee('1,000.00')  // paid revenue
+        ->assertSee('150.00');   // commission (15% of 1000)
+});
+
+it('shows multiple teachers sorted by commission descending', function () {
+    $admin = User::factory()->admin()->create();
+    $top = User::factory()->create(['name' => 'AAA First Teacher']);
+    $second = User::factory()->create(['name' => 'BBB Second Teacher']);
+
+    // top earns RM 200 commission, second earns RM 50
+    $session1 = ClassSession::factory()->create([
+        'session_date' => now()->startOfMonth()->addDays(2),
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$top->id],
+        'upsell_teacher_commission_rate' => 10,
+    ]);
+    $session2 = ClassSession::factory()->create([
+        'session_date' => now()->startOfMonth()->addDays(3),
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$second->id],
+        'upsell_teacher_commission_rate' => 10,
+    ]);
+
+    $paid1 = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    $paid2 = ProductOrder::factory()->create(['payment_status' => 'paid']);
+
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session1->id,
+        'product_order_id' => $paid1->id,
+        'funnel_revenue' => 2000,
+    ]);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session2->id,
+        'product_order_id' => $paid2->id,
+        'funnel_revenue' => 500,
+    ]);
+
+    $this->actingAs($admin);
+
+    Volt::test('admin.upsell-dashboard')
+        ->assertSeeInOrder(['AAA First Teacher', 'BBB Second Teacher']); // top first
+});
+
+it('shows empty state when no teacher data', function () {
+    $admin = User::factory()->admin()->create();
+    $this->actingAs($admin);
+
+    Volt::test('admin.upsell-dashboard')
+        ->assertSee('No teacher data in selected period');
+});

--- a/tests/Unit/Services/UpsellPaidOrdersQueryTest.php
+++ b/tests/Unit/Services/UpsellPaidOrdersQueryTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ClassSession;
+use App\Models\FunnelOrder;
+use App\Models\Product;
+use App\Models\ProductOrder;
+use App\Models\ProductOrderItem;
+use App\Models\User;
+use App\Services\Upsell\UpsellPaidOrdersQuery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+it('only returns paid funnel orders', function () {
+    $session = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [1],
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    $pending = ProductOrder::factory()->create(['payment_status' => 'pending']);
+
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 100,
+    ]);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $pending->id,
+        'funnel_revenue' => 200,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)->get();
+
+    expect($rows)->toHaveCount(1);
+});
+
+it('excludes orders whose session has no upsell_funnel_ids', function () {
+    $sessionWithUpsell = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [1],
+    ]);
+    $sessionWithoutUpsell = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => null,
+        'upsell_teacher_ids' => null,
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+
+    FunnelOrder::factory()->create([
+        'class_session_id' => $sessionWithUpsell->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 100,
+    ]);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $sessionWithoutUpsell->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 200,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)->get();
+
+    expect($rows)->toHaveCount(1);
+});
+
+it('filters by date range', function () {
+    $inRange = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [1],
+        'session_date' => '2026-05-15',
+    ]);
+    $outOfRange = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [1],
+        'session_date' => '2026-03-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $inRange->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 100,
+    ]);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $outOfRange->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 100,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)
+        ->forDateRange('2026-05-01', '2026-05-31')
+        ->get();
+
+    expect($rows)->toHaveCount(1);
+});
+
+it('filters by funnel id', function () {
+    $session = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => [7],
+        'upsell_teacher_ids' => [1],
+    ]);
+    $otherSession = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => [99],
+        'upsell_teacher_ids' => [1],
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 100,
+    ]);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $otherSession->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 100,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)
+        ->forFunnelId(7)
+        ->get();
+
+    expect($rows)->toHaveCount(1);
+});
+
+it('filters by pic id', function () {
+    $session = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => [1],
+        'upsell_pic_user_ids' => [42],
+        'upsell_teacher_ids' => [1],
+    ]);
+    $otherSession = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => [1],
+        'upsell_pic_user_ids' => [99],
+        'upsell_teacher_ids' => [1],
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 100,
+    ]);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $otherSession->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 100,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)
+        ->forPicId(42)
+        ->get();
+
+    expect($rows)->toHaveCount(1);
+});
+
+it('groups by teacher with single teacher', function () {
+    $teacher = User::factory()->create(['name' => 'Teacher A']);
+    $session = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)->byTeacher();
+
+    expect($rows)->toHaveCount(1);
+    expect($rows->first()['teacher_id'])->toBe($teacher->id);
+    expect($rows->first()['teacher_name'])->toBe('Teacher A');
+    expect($rows->first()['paid_orders'])->toBe(1);
+    expect($rows->first()['sessions_count'])->toBe(1);
+    expect((float) $rows->first()['paid_revenue'])->toBe(1000.0);
+    expect((float) $rows->first()['commission_earned'])->toBe(100.0);
+});
+
+it('splits commission across multiple teachers on a session', function () {
+    $teacher1 = User::factory()->create();
+    $teacher2 = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher1->id, $teacher2->id],
+        'upsell_teacher_commission_rate' => 10,
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)->byTeacher()->keyBy('teacher_id');
+
+    expect($rows)->toHaveCount(2);
+    expect((float) $rows[$teacher1->id]['commission_earned'])->toBe(50.0);
+    expect((float) $rows[$teacher2->id]['commission_earned'])->toBe(50.0);
+    expect((float) $rows[$teacher1->id]['paid_revenue'])->toBe(500.0);
+    expect((float) $rows[$teacher2->id]['paid_revenue'])->toBe(500.0);
+});
+
+it('skips funnel orders whose session has no upsell teachers in byTeacher', function () {
+    $session = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => null,
+        'upsell_teacher_commission_rate' => 10,
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 500,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)->byTeacher();
+
+    expect($rows)->toHaveCount(0);
+});
+
+it('groups by product with line type from funnel order', function () {
+    $session = ClassSession::factory()->create([
+        'session_date' => '2026-05-15',
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [1],
+        'upsell_teacher_commission_rate' => 10,
+    ]);
+
+    $mainProduct = Product::factory()->create();
+    $bumpProduct = Product::factory()->create();
+
+    $mainOrder = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    ProductOrderItem::factory()->create([
+        'order_id' => $mainOrder->id,
+        'product_id' => $mainProduct->id,
+        'product_name' => 'Main Course',
+        'quantity_ordered' => 2,
+        'total_price' => 200,
+    ]);
+
+    $bumpOrder = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    ProductOrderItem::factory()->create([
+        'order_id' => $bumpOrder->id,
+        'product_id' => $bumpProduct->id,
+        'product_name' => 'Bump Product',
+        'quantity_ordered' => 1,
+        'total_price' => 50,
+    ]);
+
+    FunnelOrder::factory()->create([
+        'funnel_id' => 1,
+        'class_session_id' => $session->id,
+        'product_order_id' => $mainOrder->id,
+        'order_type' => 'main',
+        'funnel_revenue' => 200,
+    ]);
+    FunnelOrder::factory()->create([
+        'funnel_id' => 1,
+        'class_session_id' => $session->id,
+        'product_order_id' => $bumpOrder->id,
+        'order_type' => 'bump',
+        'funnel_revenue' => 50,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)->byProduct();
+
+    expect($rows)->toHaveCount(2);
+
+    $byId = $rows->keyBy('product_id');
+    expect($byId[$mainProduct->id]['product_name'])->toBe('Main Course');
+    expect($byId[$mainProduct->id]['line_type'])->toBe('main');
+    expect($byId[$mainProduct->id]['units'])->toBe(2);
+    expect((float) $byId[$mainProduct->id]['revenue'])->toBe(200.0);
+
+    expect($byId[$bumpProduct->id]['product_name'])->toBe('Bump Product');
+    expect($byId[$bumpProduct->id]['line_type'])->toBe('bump');
+    expect($byId[$bumpProduct->id]['units'])->toBe(1);
+    expect((float) $byId[$bumpProduct->id]['revenue'])->toBe(50.0);
+
+    // Sorted by revenue descending
+    expect($rows->first()['product_id'])->toBe($mainProduct->id);
+});


### PR DESCRIPTION
## Summary

Phase B of the upsell system improvements. Adds three reports on top of Phase A's paid-orders dataset:

- **By Teacher** table on the upsell dashboard — sessions, paid orders, revenue, commission earned, top products. Multi-teacher sessions split equally.
- **By Product** table on the upsell dashboard — line-level (main / bump / upsell / downsell), funnels, units, revenue.
- **Upsell Performance** section on the admin teacher detail page — 4 stat cards + sessions table with own date range filter (defaults to last 90 days).

All three read from a new shared `UpsellPaidOrdersQuery` service so the rules stay consistent.

## Depends on

**Phase A PR #12 must merge first.** This PR is based off the Phase A branch.

## Key implementation notes

- `class_sessions.upsell_teacher_ids` is a JSON array (multiple teachers per session). When grouping by teacher, revenue and commission are **split equally** across each listed teacher.
- Product line type (main / bump / upsell / downsell) is derived from `funnel_orders.order_type` since `product_order_items` has no line-type column.
- The teacher detail page didn't have a tab structure, so the new section was added as a card (consistent with the existing Information / Banking / Courses cards) rather than converting to tabs.

## Test plan

- [ ] Open `/admin/upsell-dashboard`. Confirm the new "Performance by Teacher" and "Performance by Product" sections render with correct data.
- [ ] Filter by date range — confirm all three sections respect the filter.
- [ ] Filter by funnel / PIC — confirm both new tables update.
- [ ] Open `/admin/teachers/{id}` for a teacher with upsell sessions. Confirm the "Upsell Performance" section shows real numbers.
- [ ] Change the date range on the teacher page — confirm stats update.
- [ ] Confirm a teacher with no upsell sessions shows the empty state.
- [ ] Run: `php artisan test --compact tests/Unit/Services/UpsellPaidOrdersQueryTest.php tests/Feature/Livewire/Admin/UpsellDashboard*Test.php tests/Feature/Livewire/Admin/TeacherShow*Test.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)