### PR TITLE
Phase C: accountant workflow — PDF receipts + commission payouts

### DIFF
--- a/app/Http/Controllers/Admin/ProductOrderReceiptController.php
+++ b/app/Http/Controllers/Admin/ProductOrderReceiptController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\ProductOrder;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ProductOrderReceiptController extends Controller
+{
+    /**
+     * Stream a downloadable PDF receipt for the given product order.
+     *
+     * Loads the same relationships as the order-receipt Volt component so the
+     * existing PDF template renders identically when downloaded via this route.
+     */
+    public function download(ProductOrder $order): StreamedResponse
+    {
+        $order->load([
+            'items.product',
+            'items.package',
+            'items.warehouse',
+            'customer',
+            'addresses',
+            'payments',
+            'agent',
+        ]);
+
+        $pdf = Pdf::loadView('livewire.admin.orders.order-receipt-pdf', ['order' => $order])
+            ->setPaper('a4', 'portrait')
+            ->setOptions([
+                'defaultFont' => 'DejaVu Sans',
+                'isHtml5ParserEnabled' => true,
+                'isPhpEnabled' => false,
+                'isRemoteEnabled' => false,
+            ]);
+
+        $filename = 'receipt-'.$order->order_number.'.pdf';
+
+        return response()->streamDownload(function () use ($pdf) {
+            echo $pdf->stream();
+        }, $filename, [
+            'Content-Type' => 'application/pdf',
+        ]);
+    }
+}

--- a/app/Models/UpsellCommissionPayout.php
+++ b/app/Models/UpsellCommissionPayout.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use InvalidArgumentException;
+
+class UpsellCommissionPayout extends Model
+{
+    /** @use HasFactory<\Database\Factories\UpsellCommissionPayoutFactory> */
+    use HasFactory;
+
+    public const STATUS_DRAFT = 'draft';
+
+    public const STATUS_LOCKED = 'locked';
+
+    public const STATUS_PAID = 'paid';
+
+    protected $fillable = [
+        'teacher_user_id',
+        'period_start',
+        'period_end',
+        'total_commission',
+        'session_count',
+        'status',
+        'locked_at',
+        'paid_at',
+        'payment_reference',
+        'paid_by_user_id',
+        'notes',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'period_start' => 'date',
+            'period_end' => 'date',
+            'locked_at' => 'datetime',
+            'paid_at' => 'datetime',
+            'total_commission' => 'decimal:2',
+            'session_count' => 'integer',
+        ];
+    }
+
+    public function teacher(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'teacher_user_id');
+    }
+
+    public function paidBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'paid_by_user_id');
+    }
+
+    public function sessions(): HasMany
+    {
+        return $this->hasMany(UpsellCommissionPayoutSession::class, 'upsell_commission_payout_id');
+    }
+
+    public function scopeDraft(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_DRAFT);
+    }
+
+    public function scopeLocked(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_LOCKED);
+    }
+
+    public function scopePaid(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_PAID);
+    }
+
+    public function lock(): void
+    {
+        if ($this->status !== self::STATUS_DRAFT) {
+            throw new InvalidArgumentException(
+                "Cannot lock payout in status [{$this->status}]; expected [draft]."
+            );
+        }
+
+        $this->forceFill([
+            'status' => self::STATUS_LOCKED,
+            'locked_at' => now(),
+        ])->save();
+    }
+
+    public function markPaid(int $userId, string $reference): void
+    {
+        if ($this->status !== self::STATUS_LOCKED) {
+            throw new InvalidArgumentException(
+                "Cannot mark paid in status [{$this->status}]; expected [locked]."
+            );
+        }
+
+        $this->forceFill([
+            'status' => self::STATUS_PAID,
+            'paid_at' => now(),
+            'paid_by_user_id' => $userId,
+            'payment_reference' => $reference,
+        ])->save();
+    }
+}

--- a/app/Models/UpsellCommissionPayoutSession.php
+++ b/app/Models/UpsellCommissionPayoutSession.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UpsellCommissionPayoutSession extends Model
+{
+    /** @use HasFactory<\Database\Factories\UpsellCommissionPayoutSessionFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'upsell_commission_payout_id',
+        'class_session_id',
+        'paid_revenue',
+        'commission_rate',
+        'commission_amount',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'paid_revenue' => 'decimal:2',
+            'commission_rate' => 'decimal:2',
+            'commission_amount' => 'decimal:2',
+        ];
+    }
+
+    public function payout(): BelongsTo
+    {
+        return $this->belongsTo(UpsellCommissionPayout::class, 'upsell_commission_payout_id');
+    }
+
+    public function classSession(): BelongsTo
+    {
+        return $this->belongsTo(ClassSession::class, 'class_session_id');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -65,6 +65,8 @@ class AppServiceProvider extends ServiceProvider
         Gate::define('livehost.update', fn (User $actor, User $target) => (new LiveHostPolicy)->update($actor, $target));
         Gate::define('livehost.delete', fn (User $actor, User $target) => (new LiveHostPolicy)->delete($actor, $target));
 
+        Gate::define('manageUpsellCommissions', fn (User $user) => $user->hasRole('accountant') || $user->hasRole('admin'));
+
         Gate::policy(ProductOrder::class, ProductOrderPolicy::class);
 
         LiveSession::observe(LiveSessionVerifiedObserver::class);

--- a/app/Services/Upsell/CommissionPayoutService.php
+++ b/app/Services/Upsell/CommissionPayoutService.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Upsell;
+
+use App\Models\ClassSession;
+use App\Models\FunnelOrder;
+use App\Models\UpsellCommissionPayout;
+use App\Models\UpsellCommissionPayoutSession;
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Builds per-teacher commission payouts from paid upsell funnel orders.
+ *
+ * Mirrors the Phase B `UpsellPaidOrdersQuery::byTeacher()` splitting rules:
+ * when a session lists N upsell teachers, the per-order commission is split
+ * equally among them.
+ */
+class CommissionPayoutService
+{
+    /**
+     * Preview per-teacher unpaid commission within a date window.
+     *
+     * Sessions that already appear in an existing payout (draft, locked, or
+     * paid) are excluded to prevent double-payment.
+     *
+     * @return Collection<int, array{
+     *     teacher_id: int,
+     *     teacher_name: string|null,
+     *     session_ids: Collection<int, int>,
+     *     session_count: int,
+     *     commission_total: float,
+     * }>
+     */
+    public function preview(string $from, string $to): Collection
+    {
+        $alreadyCovered = UpsellCommissionPayoutSession::query()
+            ->pluck('class_session_id')
+            ->all();
+
+        $orders = FunnelOrder::query()
+            ->whereHas('productOrder', fn ($q) => $q->where('payment_status', 'paid'))
+            ->whereHas('classSession', function ($q) use ($from, $to) {
+                $q->whereNotNull('upsell_funnel_ids')
+                    ->whereDate('session_date', '>=', $from)
+                    ->whereDate('session_date', '<=', $to);
+            })
+            ->when(! empty($alreadyCovered), function ($q) use ($alreadyCovered) {
+                $q->whereNotIn('class_session_id', $alreadyCovered);
+            })
+            ->with('classSession')
+            ->get();
+
+        $byTeacher = [];
+
+        foreach ($orders as $order) {
+            $session = $order->classSession;
+            if (! $session) {
+                continue;
+            }
+
+            $teacherIds = $session->upsell_teacher_ids ?? [];
+            if (empty($teacherIds)) {
+                continue;
+            }
+
+            $split = count($teacherIds);
+            $rate = (float) ($session->upsell_teacher_commission_rate ?? 0);
+            $orderCommission = ((float) $order->funnel_revenue) * ($rate / 100);
+            $share = $orderCommission / $split;
+
+            foreach ($teacherIds as $teacherId) {
+                $teacherId = (int) $teacherId;
+
+                if (! isset($byTeacher[$teacherId])) {
+                    $byTeacher[$teacherId] = [
+                        'teacher_id' => $teacherId,
+                        'session_ids' => [],
+                        'commission_total' => 0.0,
+                    ];
+                }
+
+                $byTeacher[$teacherId]['session_ids'][$session->id] = true;
+                $byTeacher[$teacherId]['commission_total'] += $share;
+            }
+        }
+
+        if (empty($byTeacher)) {
+            return collect();
+        }
+
+        $users = User::query()
+            ->whereIn('id', array_keys($byTeacher))
+            ->get()
+            ->keyBy('id');
+
+        return collect($byTeacher)
+            ->map(function (array $row) use ($users): array {
+                $sessionIds = collect(array_keys($row['session_ids']))->values();
+
+                return [
+                    'teacher_id' => $row['teacher_id'],
+                    'teacher_name' => $users->get($row['teacher_id'])?->name,
+                    'session_ids' => $sessionIds,
+                    'session_count' => $sessionIds->count(),
+                    'commission_total' => round($row['commission_total'], 2),
+                ];
+            })
+            ->sortByDesc('commission_total')
+            ->values();
+    }
+
+    /**
+     * Create a draft payout for one teacher across the given session ids.
+     *
+     * @param  array<int>  $sessionIds
+     */
+    public function createPayout(int $teacherUserId, string $from, string $to, array $sessionIds): UpsellCommissionPayout
+    {
+        if (empty($sessionIds)) {
+            throw new InvalidArgumentException('At least one session id is required to create a payout.');
+        }
+
+        return DB::transaction(function () use ($teacherUserId, $from, $to, $sessionIds) {
+            $sessions = ClassSession::query()
+                ->whereIn('id', $sessionIds)
+                ->get()
+                ->keyBy('id');
+
+            $missing = collect($sessionIds)->diff($sessions->keys());
+            if ($missing->isNotEmpty()) {
+                throw new InvalidArgumentException(
+                    'Unknown class session ids: '.$missing->implode(', ')
+                );
+            }
+
+            $totalCommission = 0.0;
+            $sessionRows = [];
+
+            foreach ($sessions as $session) {
+                $teacherIds = $session->upsell_teacher_ids ?? [];
+                if (! in_array($teacherUserId, $teacherIds, false)) {
+                    throw new InvalidArgumentException(
+                        "Teacher {$teacherUserId} is not assigned to session {$session->id}."
+                    );
+                }
+
+                $split = count($teacherIds);
+                $rate = (float) ($session->upsell_teacher_commission_rate ?? 0);
+
+                $paidRevenueForSession = (float) FunnelOrder::query()
+                    ->where('class_session_id', $session->id)
+                    ->whereHas('productOrder', fn ($q) => $q->where('payment_status', 'paid'))
+                    ->sum('funnel_revenue');
+
+                if ($paidRevenueForSession <= 0) {
+                    throw new RuntimeException(
+                        "Session {$session->id} has no paid funnel revenue to pay out."
+                    );
+                }
+
+                $share = ($paidRevenueForSession * ($rate / 100)) / $split;
+                $totalCommission += $share;
+
+                $sessionRows[] = [
+                    'class_session_id' => $session->id,
+                    'paid_revenue' => round($paidRevenueForSession, 2),
+                    'commission_rate' => round($rate, 2),
+                    'commission_amount' => round($share, 2),
+                ];
+            }
+
+            $payout = UpsellCommissionPayout::create([
+                'teacher_user_id' => $teacherUserId,
+                'period_start' => $from,
+                'period_end' => $to,
+                'total_commission' => round($totalCommission, 2),
+                'session_count' => count($sessionRows),
+                'status' => UpsellCommissionPayout::STATUS_DRAFT,
+            ]);
+
+            foreach ($sessionRows as $row) {
+                $payout->sessions()->create($row);
+            }
+
+            return $payout->fresh('sessions');
+        });
+    }
+}

--- a/app/Services/Upsell/UpsellPaidOrdersQuery.php
+++ b/app/Services/Upsell/UpsellPaidOrdersQuery.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Services\Upsell;
 
 use App\Models\FunnelOrder;
+use App\Models\UpsellCommissionPayout;
+use App\Models\UpsellCommissionPayoutSession;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -107,6 +109,8 @@ class UpsellPaidOrdersQuery
      *     paid_orders: int,
      *     paid_revenue: float,
      *     commission_earned: float,
+     *     commission_paid: float,
+     *     commission_pending: float,
      *     top_products: SupportCollection<int, array{product_id: int|null, product_name: string, units: int, revenue: float}>,
      * }>
      */
@@ -180,9 +184,10 @@ class UpsellPaidOrdersQuery
         }
 
         $users = User::whereIn('id', array_keys($byTeacher))->get()->keyBy('id');
+        $paidByTeacher = $this->paidCommissionByTeacher(array_keys($byTeacher));
 
         return collect($byTeacher)
-            ->map(function (array $row) use ($users): array {
+            ->map(function (array $row) use ($users, $paidByTeacher): array {
                 $user = $users->get($row['teacher_id']);
 
                 $topProducts = collect($row['product_lines'])
@@ -190,18 +195,64 @@ class UpsellPaidOrdersQuery
                     ->take(5)
                     ->values();
 
+                $earned = round($row['commission_earned'], 2);
+                $paid = round((float) ($paidByTeacher[$row['teacher_id']] ?? 0), 2);
+                $pending = round(max(0.0, $earned - $paid), 2);
+
                 return [
                     'teacher_id' => $row['teacher_id'],
                     'teacher_name' => $user?->name,
                     'sessions_count' => count($row['session_ids']),
                     'paid_orders' => $row['paid_orders'],
                     'paid_revenue' => round($row['paid_revenue'], 2),
-                    'commission_earned' => round($row['commission_earned'], 2),
+                    'commission_earned' => $earned,
+                    'commission_paid' => $paid,
+                    'commission_pending' => $pending,
                     'top_products' => $topProducts,
                 ];
             })
             ->sortByDesc('commission_earned')
             ->values();
+    }
+
+    /**
+     * Sum of paid commission per teacher, scoped to the active date range.
+     *
+     * "Paid" here means: belongs to an UpsellCommissionPayout with
+     * status='paid', for sessions whose `session_date` falls in the same
+     * date range used by commission_earned. We deliberately filter on
+     * session_date (not payout.paid_at) so that "paid" is the subset of
+     * "earned" for the same reporting period.
+     *
+     * @param  array<int, int>  $teacherIds
+     * @return array<int, float>
+     */
+    private function paidCommissionByTeacher(array $teacherIds): array
+    {
+        if (empty($teacherIds)) {
+            return [];
+        }
+
+        $query = UpsellCommissionPayoutSession::query()
+            ->select('upsell_commission_payouts.teacher_user_id')
+            ->selectRaw('SUM(upsell_commission_payout_sessions.commission_amount) as paid_total')
+            ->join('upsell_commission_payouts', 'upsell_commission_payouts.id', '=', 'upsell_commission_payout_sessions.upsell_commission_payout_id')
+            ->join('class_sessions', 'class_sessions.id', '=', 'upsell_commission_payout_sessions.class_session_id')
+            ->where('upsell_commission_payouts.status', UpsellCommissionPayout::STATUS_PAID)
+            ->whereIn('upsell_commission_payouts.teacher_user_id', $teacherIds);
+
+        if ($this->from) {
+            $query->whereDate('class_sessions.session_date', '>=', $this->from);
+        }
+
+        if ($this->to) {
+            $query->whereDate('class_sessions.session_date', '<=', $this->to);
+        }
+
+        return $query->groupBy('upsell_commission_payouts.teacher_user_id')
+            ->pluck('paid_total', 'teacher_user_id')
+            ->map(fn ($v) => (float) $v)
+            ->all();
     }
 
     /**

--- a/database/factories/UpsellCommissionPayoutFactory.php
+++ b/database/factories/UpsellCommissionPayoutFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\UpsellCommissionPayout>
+ */
+class UpsellCommissionPayoutFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'teacher_user_id' => User::factory(),
+            'period_start' => '2026-05-01',
+            'period_end' => '2026-05-31',
+            'total_commission' => 100.00,
+            'session_count' => 1,
+            'status' => 'draft',
+            'locked_at' => null,
+            'paid_at' => null,
+            'payment_reference' => null,
+            'paid_by_user_id' => null,
+            'notes' => null,
+        ];
+    }
+
+    public function draft(): static
+    {
+        return $this->state(fn () => ['status' => 'draft']);
+    }
+
+    public function locked(): static
+    {
+        return $this->state(fn () => [
+            'status' => 'locked',
+            'locked_at' => now(),
+        ]);
+    }
+
+    public function paid(): static
+    {
+        return $this->state(fn () => [
+            'status' => 'paid',
+            'locked_at' => now()->subDay(),
+            'paid_at' => now(),
+            'payment_reference' => 'TXN-'.fake()->unique()->numerify('######'),
+            'paid_by_user_id' => User::factory(),
+        ]);
+    }
+}

--- a/database/factories/UpsellCommissionPayoutSessionFactory.php
+++ b/database/factories/UpsellCommissionPayoutSessionFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ClassSession;
+use App\Models\UpsellCommissionPayout;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\UpsellCommissionPayoutSession>
+ */
+class UpsellCommissionPayoutSessionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'upsell_commission_payout_id' => UpsellCommissionPayout::factory(),
+            'class_session_id' => ClassSession::factory(),
+            'paid_revenue' => 1000.00,
+            'commission_rate' => 10.00,
+            'commission_amount' => 100.00,
+        ];
+    }
+}

--- a/database/migrations/2026_05_20_000010_create_upsell_commission_payouts_table.php
+++ b/database/migrations/2026_05_20_000010_create_upsell_commission_payouts_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('upsell_commission_payouts')) {
+            return;
+        }
+
+        Schema::create('upsell_commission_payouts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('teacher_user_id')->constrained('users')->cascadeOnDelete();
+            $table->date('period_start');
+            $table->date('period_end');
+            $table->decimal('total_commission', 12, 2);
+            $table->integer('session_count');
+            $table->string('status', 20)->default('draft')->index();
+            $table->timestamp('locked_at')->nullable();
+            $table->timestamp('paid_at')->nullable();
+            $table->string('payment_reference', 100)->nullable();
+            $table->foreignId('paid_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->index(['period_start', 'period_end']);
+            $table->index('teacher_user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('upsell_commission_payouts');
+    }
+};

--- a/database/migrations/2026_05_20_000011_create_upsell_commission_payout_sessions_table.php
+++ b/database/migrations/2026_05_20_000011_create_upsell_commission_payout_sessions_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('upsell_commission_payout_sessions')) {
+            return;
+        }
+
+        Schema::create('upsell_commission_payout_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('upsell_commission_payout_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('class_session_id')->constrained()->cascadeOnDelete();
+            $table->decimal('paid_revenue', 12, 2);
+            $table->decimal('commission_rate', 5, 2);
+            $table->decimal('commission_amount', 12, 2);
+            $table->timestamps();
+
+            $table->unique(['upsell_commission_payout_id', 'class_session_id'], 'payout_session_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('upsell_commission_payout_sessions');
+    }
+};

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -12,7 +12,8 @@
                 currentRoute: '{{ request()->route()?->getName() }}',
                 sectionRoutes: {
                     'platform': ['dashboard'],
-                    'administration': ['courses.*', 'users.*', 'students.*', 'teachers.*', 'classes.*', 'class-categories.*', 'admin.sessions.*', 'admin.payslips.*', 'enrollments.*', 'admin.upsell-dashboard'],
+                    'administration': ['courses.*', 'users.*', 'students.*', 'teachers.*', 'classes.*', 'class-categories.*', 'admin.sessions.*', 'admin.payslips.*', 'enrollments.*', 'admin.upsell-dashboard', 'admin.upsell-commissions'],
+                    'accounting': ['admin.upsell-commissions', 'admin.orders.*'],
                     'subscription': ['orders.*', 'admin.payments*'],
                     'products': ['products.*', 'product-categories.*', 'product-attributes.*'],
                     'crm': ['crm.*', 'admin.funnel-email-templates*'],
@@ -140,6 +141,9 @@
                     <flux:navlist.item icon="banknotes" :href="route('admin.payslips.index')" :current="request()->routeIs('admin.payslips.*')" wire:navigate>{{ __('Payslips') }}</flux:navlist.item>
                     <flux:navlist.item icon="clipboard" :href="route('enrollments.index')" :current="request()->routeIs('enrollments.*')" wire:navigate>{{ __('Enrollments') }}</flux:navlist.item>
                     <flux:navlist.item icon="gift" :href="route('admin.upsell-dashboard')" :current="request()->routeIs('admin.upsell-dashboard')" wire:navigate>{{ __('Upsell Dashboard') }}</flux:navlist.item>
+                    @if(auth()->user()->isAdmin())
+                        <flux:navlist.item icon="banknotes" :href="route('admin.upsell-commissions')" :current="request()->routeIs('admin.upsell-commissions')" wire:navigate>{{ __('Upsell Commission Payouts') }}</flux:navlist.item>
+                    @endif
                 </flux:navlist.group>
 
                 <flux:navlist.group
@@ -473,6 +477,18 @@
                     <flux:navlist.item icon="calculator" :href="route('pos.index')" :current="request()->routeIs('pos.*')">{{ __('POS - Point of Sale') }}</flux:navlist.item>
                     <flux:navlist.item icon="tag" :href="route('admin.sales-sources')" :current="request()->routeIs('admin.sales-sources')" wire:navigate>{{ __('Sales Sources') }}</flux:navlist.item>
                     <flux:navlist.item icon="document-chart-bar" :href="route('admin.reports.sales-department')" :current="request()->routeIs('admin.reports.sales-department')" wire:navigate>{{ __('Sales Department Report') }}</flux:navlist.item>
+                </flux:navlist.group>
+                @endif
+
+                @if(auth()->user()->hasRole('accountant'))
+                <flux:navlist.group
+                    expandable
+                    :heading="__('Accounting')"
+                    data-section='accounting' x-init="if (!isExpanded('accounting')) { $nextTick(() => { const btn = $el.querySelector('button'); if (btn && $el.hasAttribute('open')) btn.click(); }); }"
+                    @click="saveState('accounting', $event)"
+                >
+                    <flux:navlist.item icon="shopping-bag" :href="route('admin.orders.index')" :current="request()->routeIs('admin.orders.index') || request()->routeIs('admin.orders.show')" wire:navigate>{{ __('Product Orders') }}</flux:navlist.item>
+                    <flux:navlist.item icon="banknotes" :href="route('admin.upsell-commissions')" :current="request()->routeIs('admin.upsell-commissions')" wire:navigate>{{ __('Upsell Commission Payouts') }}</flux:navlist.item>
                 </flux:navlist.group>
                 @endif
 

--- a/resources/views/livewire/admin/orders/order-list.blade.php
+++ b/resources/views/livewire/admin/orders/order-list.blade.php
@@ -1805,6 +1805,12 @@ new class extends Component
                                         <flux:icon name="eye" class="w-4 h-4" />
                                     </a>
 
+                                    <a href="{{ route('admin.orders.receipt-pdf', $order) }}" target="_blank"
+                                       title="Download receipt PDF"
+                                       class="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 dark:hover:text-zinc-300 dark:hover:bg-zinc-700 transition-colors">
+                                        <flux:icon name="arrow-down-tray" class="w-4 h-4" />
+                                    </a>
+
                                     @if($order->canBeCancelled() || $order->status === 'delivered')
                                         <flux:dropdown>
                                             <flux:button variant="ghost" size="sm">

--- a/resources/views/livewire/admin/orders/order-receipt-pdf.blade.php
+++ b/resources/views/livewire/admin/orders/order-receipt-pdf.blade.php
@@ -5,51 +5,57 @@
     <title>Invoice - {{ $order->order_number }}</title>
     <style>
         @php
-            function numberToWordsHelper($number) {
-                $ones = ['', 'ONE', 'TWO', 'THREE', 'FOUR', 'FIVE', 'SIX', 'SEVEN', 'EIGHT', 'NINE', 'TEN', 'ELEVEN', 'TWELVE', 'THIRTEEN', 'FOURTEEN', 'FIFTEEN', 'SIXTEEN', 'SEVENTEEN', 'EIGHTEEN', 'NINETEEN'];
-                $tens = ['', '', 'TWENTY', 'THIRTY', 'FORTY', 'FIFTY', 'SIXTY', 'SEVENTY', 'EIGHTY', 'NINETY'];
+            if (! function_exists('numberToWordsHelper')) {
+                function numberToWordsHelper($number) {
+                    $ones = ['', 'ONE', 'TWO', 'THREE', 'FOUR', 'FIVE', 'SIX', 'SEVEN', 'EIGHT', 'NINE', 'TEN', 'ELEVEN', 'TWELVE', 'THIRTEEN', 'FOURTEEN', 'FIFTEEN', 'SIXTEEN', 'SEVENTEEN', 'EIGHTEEN', 'NINETEEN'];
+                    $tens = ['', '', 'TWENTY', 'THIRTY', 'FORTY', 'FIFTY', 'SIXTY', 'SEVENTY', 'EIGHTY', 'NINETY'];
 
-                $integer = floor($number);
-                $decimal = round(($number - $integer) * 100);
+                    $integer = floor($number);
+                    $decimal = round(($number - $integer) * 100);
 
-                $words = '';
+                    $words = '';
 
-                if ($integer >= 1000) {
-                    $thousands = floor($integer / 1000);
-                    $words .= convertHundredsHelper($thousands, $ones, $tens) . ' THOUSAND ';
-                    $integer %= 1000;
+                    if ($integer >= 1000) {
+                        $thousands = floor($integer / 1000);
+                        $words .= convertHundredsHelper($thousands, $ones, $tens) . ' THOUSAND ';
+                        $integer %= 1000;
+                    }
+
+                    if ($integer >= 100) {
+                        $words .= convertHundredsHelper($integer, $ones, $tens);
+                    } elseif ($integer > 0) {
+                        $words .= convertTensHelper($integer, $ones, $tens);
+                    }
+
+                    $words = trim($words);
+
+                    if ($decimal > 0) {
+                        $words .= ' AND CENTS ' . convertTensHelper($decimal, $ones, $tens);
+                    }
+
+                    return 'RINGGIT MALAYSIA : ' . $words . ' ONLY';
                 }
-
-                if ($integer >= 100) {
-                    $words .= convertHundredsHelper($integer, $ones, $tens);
-                } elseif ($integer > 0) {
-                    $words .= convertTensHelper($integer, $ones, $tens);
-                }
-
-                $words = trim($words);
-
-                if ($decimal > 0) {
-                    $words .= ' AND CENTS ' . convertTensHelper($decimal, $ones, $tens);
-                }
-
-                return 'RINGGIT MALAYSIA : ' . $words . ' ONLY';
             }
 
-            function convertHundredsHelper($number, $ones, $tens) {
-                $result = '';
-                if ($number >= 100) {
-                    $result .= $ones[floor($number / 100)] . ' HUNDRED ';
-                    $number %= 100;
+            if (! function_exists('convertHundredsHelper')) {
+                function convertHundredsHelper($number, $ones, $tens) {
+                    $result = '';
+                    if ($number >= 100) {
+                        $result .= $ones[floor($number / 100)] . ' HUNDRED ';
+                        $number %= 100;
+                    }
+                    $result .= convertTensHelper($number, $ones, $tens);
+                    return trim($result);
                 }
-                $result .= convertTensHelper($number, $ones, $tens);
-                return trim($result);
             }
 
-            function convertTensHelper($number, $ones, $tens) {
-                if ($number < 20) {
-                    return $ones[$number];
+            if (! function_exists('convertTensHelper')) {
+                function convertTensHelper($number, $ones, $tens) {
+                    if ($number < 20) {
+                        return $ones[$number];
+                    }
+                    return $tens[floor($number / 10)] . ' ' . $ones[$number % 10];
                 }
-                return $tens[floor($number / 10)] . ' ' . $ones[$number % 10];
             }
 
             $date = $order->order_date ?? $order->created_at;

--- a/resources/views/livewire/admin/orders/order-show.blade.php
+++ b/resources/views/livewire/admin/orders/order-show.blade.php
@@ -698,6 +698,12 @@ new class extends Component
                         Receipt
                     </div>
                 </flux:button>
+                <flux:button variant="outline" size="sm" :href="route('admin.orders.receipt-pdf', $order)" target="_blank">
+                    <div class="flex items-center justify-center">
+                        <flux:icon name="arrow-down-tray" class="w-4 h-4 mr-1" />
+                        Download PDF
+                    </div>
+                </flux:button>
                 <flux:button variant="outline" size="sm" :href="route('admin.orders.edit', $order)" wire:navigate>
                     <div class="flex items-center justify-center">
                         <flux:icon name="pencil" class="w-4 h-4 mr-1" />

--- a/resources/views/livewire/admin/teacher-show.blade.php
+++ b/resources/views/livewire/admin/teacher-show.blade.php
@@ -35,6 +35,8 @@ new class extends Component
             'paid_orders' => 0,
             'paid_revenue' => 0,
             'commission_earned' => 0,
+            'commission_paid' => 0,
+            'commission_pending' => 0,
             'top_products' => collect(),
         ];
 
@@ -261,7 +263,7 @@ new class extends Component
             </div>
         </div>
         <div class="p-6">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
                 <div class="border rounded p-4 dark:border-zinc-700">
                     <div class="text-xs text-gray-600 dark:text-gray-400 uppercase">Sessions with Upsell</div>
                     <div class="text-2xl font-bold mt-1">{{ $this->upsellStats['sessions_count'] }}</div>
@@ -277,6 +279,10 @@ new class extends Component
                 <div class="border rounded p-4 dark:border-zinc-700">
                     <div class="text-xs text-gray-600 dark:text-gray-400 uppercase">Commission Earned</div>
                     <div class="text-2xl font-bold mt-1 text-amber-600">RM {{ number_format((float) $this->upsellStats['commission_earned'], 2) }}</div>
+                </div>
+                <div class="border rounded p-4 dark:border-zinc-700">
+                    <div class="text-xs text-gray-600 dark:text-gray-400 uppercase">Commission Paid</div>
+                    <div class="text-2xl font-bold mt-1 text-emerald-600">RM {{ number_format((float) ($this->upsellStats['commission_paid'] ?? 0), 2) }}</div>
                 </div>
             </div>
 

--- a/resources/views/livewire/admin/upsell-commission-payouts.blade.php
+++ b/resources/views/livewire/admin/upsell-commission-payouts.blade.php
@@ -1,0 +1,330 @@
+<?php
+
+use App\Models\UpsellCommissionPayout;
+use App\Services\Upsell\CommissionPayoutService;
+use Livewire\Volt\Component;
+
+new class extends Component
+{
+    public string $from = '';
+
+    public string $to = '';
+
+    /** @var array<int, array<string, mixed>> */
+    public array $preview = [];
+
+    public ?int $payoutBeingMarkedPaid = null;
+
+    public string $paymentReference = '';
+
+    public function mount(): void
+    {
+        $this->authorize('manageUpsellCommissions');
+
+        $this->from = now()->startOfMonth()->toDateString();
+        $this->to = now()->toDateString();
+    }
+
+    public function loadPreview(): void
+    {
+        $this->authorize('manageUpsellCommissions');
+
+        $this->preview = app(CommissionPayoutService::class)
+            ->preview($this->from, $this->to)
+            ->map(fn (array $row): array => array_merge($row, [
+                'session_ids' => $row['session_ids']->toArray(),
+            ]))
+            ->toArray();
+    }
+
+    public function createPayout(int $teacherId): void
+    {
+        $this->authorize('manageUpsellCommissions');
+
+        $row = collect($this->preview)->firstWhere('teacher_id', $teacherId);
+        if (! $row) {
+            return;
+        }
+
+        app(CommissionPayoutService::class)
+            ->createPayout($teacherId, $this->from, $this->to, $row['session_ids']);
+
+        $this->loadPreview();
+        session()->flash('success', 'Payout draft created.');
+    }
+
+    public function lock(int $payoutId): void
+    {
+        $this->authorize('manageUpsellCommissions');
+
+        UpsellCommissionPayout::findOrFail($payoutId)->lock();
+
+        session()->flash('success', 'Payout locked.');
+    }
+
+    public function startMarkPaid(int $payoutId): void
+    {
+        $this->authorize('manageUpsellCommissions');
+
+        $this->payoutBeingMarkedPaid = $payoutId;
+        $this->paymentReference = '';
+    }
+
+    public function cancelMarkPaid(): void
+    {
+        $this->payoutBeingMarkedPaid = null;
+        $this->paymentReference = '';
+    }
+
+    public function confirmMarkPaid(): void
+    {
+        $this->authorize('manageUpsellCommissions');
+
+        $this->validate([
+            'paymentReference' => 'required|string|min:3|max:100',
+        ]);
+
+        if ($this->payoutBeingMarkedPaid === null) {
+            return;
+        }
+
+        UpsellCommissionPayout::findOrFail($this->payoutBeingMarkedPaid)
+            ->markPaid(auth()->id(), $this->paymentReference);
+
+        $this->payoutBeingMarkedPaid = null;
+        $this->paymentReference = '';
+
+        session()->flash('success', 'Payout marked as paid.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function with(): array
+    {
+        return [
+            'drafts' => UpsellCommissionPayout::draft()
+                ->with('teacher')
+                ->latest()
+                ->get(),
+            'locked' => UpsellCommissionPayout::locked()
+                ->with('teacher')
+                ->latest('locked_at')
+                ->get(),
+            'paidHistory' => UpsellCommissionPayout::paid()
+                ->with(['teacher', 'paidBy'])
+                ->latest('paid_at')
+                ->limit(50)
+                ->get(),
+        ];
+    }
+}; ?>
+
+<div>
+    <div class="mb-6 flex items-center justify-between">
+        <div>
+            <flux:heading size="xl">Upsell Commission Payouts</flux:heading>
+            <flux:text class="mt-2">Preview, create, lock, and mark commission payouts as paid</flux:text>
+        </div>
+    </div>
+
+    @if(session('success'))
+        <flux:callout variant="success" class="mb-6">
+            <flux:callout.text>{{ session('success') }}</flux:callout.text>
+        </flux:callout>
+    @endif
+
+    {{-- Section 1: Preview --}}
+    <div class="rounded-lg border border-zinc-200 dark:border-zinc-700 mb-6">
+        <div class="border-b border-zinc-200 dark:border-zinc-700 px-5 py-3">
+            <h3 class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Preview Unpaid Commissions</h3>
+            <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">Pick a date range to see eligible commissions per teacher</p>
+        </div>
+        <div class="p-4">
+            <div class="flex items-end gap-3 flex-wrap mb-4">
+                <div class="w-40 shrink-0">
+                    <flux:input type="date" wire:model="from" label="From" size="sm" />
+                </div>
+                <div class="w-40 shrink-0">
+                    <flux:input type="date" wire:model="to" label="To" size="sm" />
+                </div>
+                <flux:button variant="primary" size="sm" wire:click="loadPreview">Load Preview</flux:button>
+            </div>
+
+            @if(empty($preview))
+                <div class="py-8 text-center">
+                    <p class="text-xs text-zinc-400">No preview loaded yet. Pick a date range and click Load Preview.</p>
+                </div>
+            @else
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800">
+                            <th class="text-left py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Teacher</th>
+                            <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Sessions</th>
+                            <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Commission Total</th>
+                            <th class="text-right py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Action</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white dark:bg-zinc-900 divide-y divide-zinc-100 dark:divide-zinc-800">
+                        @foreach($preview as $row)
+                            <tr wire:key="preview-{{ $row['teacher_id'] }}" class="hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors">
+                                <td class="py-2.5 px-4 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                                    {{ $row['teacher_name'] ?? 'Unknown' }}
+                                </td>
+                                <td class="py-2.5 px-3 text-right text-sm text-zinc-600 dark:text-zinc-400 tabular-nums">{{ $row['session_count'] }}</td>
+                                <td class="py-2.5 px-3 text-right text-sm font-semibold text-amber-600 dark:text-amber-400 tabular-nums whitespace-nowrap">RM {{ number_format($row['commission_total'], 2) }}</td>
+                                <td class="py-2.5 px-4 text-right">
+                                    <flux:button size="sm" variant="primary" wire:click="createPayout({{ $row['teacher_id'] }})" wire:loading.attr="disabled" wire:target="createPayout({{ $row['teacher_id'] }})">
+                                        Create Payout
+                                    </flux:button>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            @endif
+        </div>
+    </div>
+
+    {{-- Section 2: Drafts --}}
+    <div class="rounded-lg border border-zinc-200 dark:border-zinc-700 mb-6">
+        <div class="border-b border-zinc-200 dark:border-zinc-700 px-5 py-3">
+            <h3 class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Draft Payouts</h3>
+            <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">Draft payouts can still be discarded. Lock to commit.</p>
+        </div>
+        @if($drafts->isEmpty())
+            <div class="py-8 text-center">
+                <p class="text-xs text-zinc-400">No draft payouts</p>
+            </div>
+        @else
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800">
+                        <th class="text-left py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Teacher</th>
+                        <th class="text-left py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Period</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Sessions</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Total</th>
+                        <th class="text-right py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Action</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white dark:bg-zinc-900 divide-y divide-zinc-100 dark:divide-zinc-800">
+                    @foreach($drafts as $payout)
+                        <tr wire:key="draft-{{ $payout->id }}" class="hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors">
+                            <td class="py-2.5 px-4 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                                {{ $payout->teacher?->name ?? 'Unknown' }}
+                            </td>
+                            <td class="py-2.5 px-3 text-sm text-zinc-600 dark:text-zinc-400 whitespace-nowrap">
+                                {{ $payout->period_start?->toDateString() }} → {{ $payout->period_end?->toDateString() }}
+                            </td>
+                            <td class="py-2.5 px-3 text-right text-sm text-zinc-600 dark:text-zinc-400 tabular-nums">{{ $payout->session_count }}</td>
+                            <td class="py-2.5 px-3 text-right text-sm font-semibold text-amber-600 dark:text-amber-400 tabular-nums whitespace-nowrap">RM {{ number_format((float) $payout->total_commission, 2) }}</td>
+                            <td class="py-2.5 px-4 text-right">
+                                <flux:button size="sm" variant="primary" wire:click="lock({{ $payout->id }})" wire:loading.attr="disabled">
+                                    Lock
+                                </flux:button>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        @endif
+    </div>
+
+    {{-- Section 3: Locked + Paid history --}}
+    <div class="rounded-lg border border-zinc-200 dark:border-zinc-700">
+        <div class="border-b border-zinc-200 dark:border-zinc-700 px-5 py-3">
+            <h3 class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Locked & Paid History</h3>
+            <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">Locked payouts await payment. Paid rows are read-only.</p>
+        </div>
+        @if($locked->isEmpty() && $paidHistory->isEmpty())
+            <div class="py-8 text-center">
+                <p class="text-xs text-zinc-400">No locked or paid payouts yet</p>
+            </div>
+        @else
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800">
+                        <th class="text-left py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Teacher</th>
+                        <th class="text-left py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Period</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Total</th>
+                        <th class="text-center py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Status</th>
+                        <th class="text-left py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Reference</th>
+                        <th class="text-left py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Paid At</th>
+                        <th class="text-left py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Paid By</th>
+                        <th class="text-right py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Action</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white dark:bg-zinc-900 divide-y divide-zinc-100 dark:divide-zinc-800">
+                    @foreach($locked as $payout)
+                        <tr wire:key="locked-{{ $payout->id }}" class="hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors">
+                            <td class="py-2.5 px-4 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                                {{ $payout->teacher?->name ?? 'Unknown' }}
+                            </td>
+                            <td class="py-2.5 px-3 text-sm text-zinc-600 dark:text-zinc-400 whitespace-nowrap">
+                                {{ $payout->period_start?->toDateString() }} → {{ $payout->period_end?->toDateString() }}
+                            </td>
+                            <td class="py-2.5 px-3 text-right text-sm font-semibold text-amber-600 dark:text-amber-400 tabular-nums whitespace-nowrap">RM {{ number_format((float) $payout->total_commission, 2) }}</td>
+                            <td class="py-2.5 px-3 text-center">
+                                <flux:badge color="blue" size="sm">Locked</flux:badge>
+                            </td>
+                            <td class="py-2.5 px-3 text-sm text-zinc-400">—</td>
+                            <td class="py-2.5 px-3 text-sm text-zinc-400">—</td>
+                            <td class="py-2.5 px-3 text-sm text-zinc-400">—</td>
+                            <td class="py-2.5 px-4 text-right">
+                                @if($payoutBeingMarkedPaid === $payout->id)
+                                    <div class="flex items-center justify-end gap-2">
+                                        <div class="w-48">
+                                            <flux:input
+                                                wire:model="paymentReference"
+                                                placeholder="TXN-12345"
+                                                size="sm"
+                                            />
+                                        </div>
+                                        <flux:button size="sm" variant="primary" wire:click="confirmMarkPaid" wire:loading.attr="disabled">
+                                            Confirm
+                                        </flux:button>
+                                        <flux:button size="sm" variant="ghost" wire:click="cancelMarkPaid">
+                                            Cancel
+                                        </flux:button>
+                                    </div>
+                                    @error('paymentReference')
+                                        <p class="text-xs text-red-600 dark:text-red-400 mt-1">{{ $message }}</p>
+                                    @enderror
+                                @else
+                                    <flux:button size="sm" variant="primary" wire:click="startMarkPaid({{ $payout->id }})">
+                                        Mark Paid
+                                    </flux:button>
+                                @endif
+                            </td>
+                        </tr>
+                    @endforeach
+
+                    @foreach($paidHistory as $payout)
+                        <tr wire:key="paid-{{ $payout->id }}" class="hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors">
+                            <td class="py-2.5 px-4 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                                {{ $payout->teacher?->name ?? 'Unknown' }}
+                            </td>
+                            <td class="py-2.5 px-3 text-sm text-zinc-600 dark:text-zinc-400 whitespace-nowrap">
+                                {{ $payout->period_start?->toDateString() }} → {{ $payout->period_end?->toDateString() }}
+                            </td>
+                            <td class="py-2.5 px-3 text-right text-sm font-semibold text-emerald-600 dark:text-emerald-400 tabular-nums whitespace-nowrap">RM {{ number_format((float) $payout->total_commission, 2) }}</td>
+                            <td class="py-2.5 px-3 text-center">
+                                <flux:badge color="green" size="sm">Paid</flux:badge>
+                            </td>
+                            <td class="py-2.5 px-3 text-sm text-zinc-600 dark:text-zinc-400 whitespace-nowrap">{{ $payout->payment_reference }}</td>
+                            <td class="py-2.5 px-3 text-sm text-zinc-600 dark:text-zinc-400 whitespace-nowrap">{{ $payout->paid_at?->toDateTimeString() }}</td>
+                            <td class="py-2.5 px-3 text-sm text-zinc-600 dark:text-zinc-400">{{ $payout->paidBy?->name ?? '—' }}</td>
+                            <td class="py-2.5 px-4 text-right text-sm text-zinc-400">Read-only</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/admin/upsell-dashboard.blade.php
+++ b/resources/views/livewire/admin/upsell-dashboard.blade.php
@@ -505,6 +505,8 @@ new class extends Component {
                         <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Paid Orders</th>
                         <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Paid Revenue</th>
                         <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Commission Earned</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Paid</th>
+                        <th class="text-right py-2 px-3 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Pending</th>
                         <th class="text-left py-2 px-4 text-[11px] font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">Top Products</th>
                     </tr>
                 </thead>
@@ -529,6 +531,8 @@ new class extends Component {
                             <td class="py-2.5 px-3 text-right text-sm text-zinc-600 dark:text-zinc-400 tabular-nums">{{ $row['paid_orders'] }}</td>
                             <td class="py-2.5 px-3 text-right text-sm text-zinc-600 dark:text-zinc-400 tabular-nums whitespace-nowrap">RM {{ number_format($row['paid_revenue'], 2) }}</td>
                             <td class="py-2.5 px-3 text-right text-sm font-semibold text-amber-600 dark:text-amber-400 tabular-nums whitespace-nowrap">RM {{ number_format($row['commission_earned'], 2) }}</td>
+                            <td class="py-2.5 px-3 text-right text-sm font-medium text-emerald-600 dark:text-emerald-400 tabular-nums whitespace-nowrap">RM {{ number_format($row['commission_paid'], 2) }}</td>
+                            <td class="py-2.5 px-3 text-right text-sm font-medium text-amber-600 dark:text-amber-400 tabular-nums whitespace-nowrap">RM {{ number_format($row['commission_pending'], 2) }}</td>
                             <td class="py-2.5 px-4 text-xs text-zinc-600 dark:text-zinc-400">
                                 @forelse($row['top_products']->take(3) as $product)
                                     <div class="truncate">{{ $product['product_name'] }} — RM {{ number_format($product['revenue'], 2) }}</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -623,6 +623,8 @@ Route::middleware(['auth', 'role:admin,employee,accountant'])->prefix('admin')->
     Volt::route('product-orders/report', 'admin.orders.order-report')->name('admin.orders.report');
     Volt::route('product-orders/{order}', 'admin.orders.order-show')->name('admin.orders.show');
     Volt::route('product-orders/{order}/receipt', 'admin.orders.order-receipt')->name('admin.orders.receipt');
+    Route::get('product-orders/{order}/receipt-pdf', [\App\Http\Controllers\Admin\ProductOrderReceiptController::class, 'download'])
+        ->name('admin.orders.receipt-pdf');
 });
 
 // ============================================================================

--- a/routes/web.php
+++ b/routes/web.php
@@ -628,6 +628,13 @@ Route::middleware(['auth', 'role:admin,employee,accountant'])->prefix('admin')->
 });
 
 // ============================================================================
+// UPSELL COMMISSION PAYOUTS - Accountant workflow (admin can access in emergencies)
+// ============================================================================
+Route::middleware(['auth', 'role:admin,accountant'])->prefix('admin')->group(function () {
+    Volt::route('upsell-commissions', 'admin.upsell-commission-payouts')->name('admin.upsell-commissions');
+});
+
+// ============================================================================
 // ADMIN-ONLY ROUTES - Accessible only by admin role
 // ============================================================================
 Route::middleware(['auth', 'role:admin,employee'])->prefix('admin')->group(function () {

--- a/tests/Feature/Livewire/Admin/UpsellCommissionPayoutsTest.php
+++ b/tests/Feature/Livewire/Admin/UpsellCommissionPayoutsTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ClassSession;
+use App\Models\FunnelOrder;
+use App\Models\ProductOrder;
+use App\Models\UpsellCommissionPayout;
+use App\Models\User;
+use Livewire\Volt\Volt;
+
+beforeEach(function () {
+    $this->accountant = User::factory()->create(['role' => 'accountant']);
+});
+
+it('loads the preview when accountant clicks Load Preview', function () {
+    $teacher = User::factory()->create(['name' => 'Prof X']);
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $this->actingAs($this->accountant);
+    Volt::test('admin.upsell-commission-payouts')
+        ->set('from', '2026-05-01')
+        ->set('to', '2026-05-31')
+        ->call('loadPreview')
+        ->assertSee('Prof X')
+        ->assertSee('100.00');
+});
+
+it('creates a draft payout when accountant clicks Create Payout', function () {
+    $teacher = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $this->actingAs($this->accountant);
+    Volt::test('admin.upsell-commission-payouts')
+        ->set('from', '2026-05-01')
+        ->set('to', '2026-05-31')
+        ->call('loadPreview')
+        ->call('createPayout', $teacher->id);
+
+    expect(UpsellCommissionPayout::count())->toBe(1);
+    expect(UpsellCommissionPayout::first()->status)->toBe('draft');
+});
+
+it('locks a draft payout', function () {
+    $payout = UpsellCommissionPayout::factory()->create(['status' => 'draft']);
+
+    $this->actingAs($this->accountant);
+    Volt::test('admin.upsell-commission-payouts')
+        ->call('lock', $payout->id);
+
+    expect($payout->fresh()->status)->toBe('locked');
+});
+
+it('marks a locked payout as paid with reference', function () {
+    $payout = UpsellCommissionPayout::factory()->create(['status' => 'locked', 'locked_at' => now()]);
+
+    $this->actingAs($this->accountant);
+    Volt::test('admin.upsell-commission-payouts')
+        ->call('startMarkPaid', $payout->id)
+        ->set('paymentReference', 'TXN-12345')
+        ->call('confirmMarkPaid');
+
+    expect($payout->fresh())
+        ->status->toBe('paid')
+        ->payment_reference->toBe('TXN-12345');
+});
+
+it('requires a payment reference to mark paid', function () {
+    $payout = UpsellCommissionPayout::factory()->create(['status' => 'locked', 'locked_at' => now()]);
+
+    $this->actingAs($this->accountant);
+    Volt::test('admin.upsell-commission-payouts')
+        ->call('startMarkPaid', $payout->id)
+        ->set('paymentReference', '')
+        ->call('confirmMarkPaid')
+        ->assertHasErrors(['paymentReference']);
+
+    expect($payout->fresh()->status)->toBe('locked'); // unchanged
+});
+
+it('forbids student from the page', function () {
+    $student = User::factory()->create(['role' => 'student']);
+
+    $this->actingAs($student)
+        ->get(route('admin.upsell-commissions'))
+        ->assertForbidden();
+});

--- a/tests/Feature/Livewire/Admin/UpsellDashboardTeacherBreakdownTest.php
+++ b/tests/Feature/Livewire/Admin/UpsellDashboardTeacherBreakdownTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\ClassSession;
 use App\Models\FunnelOrder;
 use App\Models\ProductOrder;
+use App\Models\UpsellCommissionPayout;
 use App\Models\User;
 use Livewire\Volt\Volt;
 
@@ -81,4 +82,41 @@ it('shows empty state when no teacher data', function () {
 
     Volt::test('admin.upsell-dashboard')
         ->assertSee('No teacher data in selected period');
+});
+
+it('shows commission paid and pending columns', function () {
+    $admin = User::factory()->admin()->create();
+    $teacher = User::factory()->create(['name' => 'Paid Teacher']);
+
+    $session = ClassSession::factory()->create([
+        'session_date' => now()->startOfMonth()->addDays(2),
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+    ]);
+
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $payout = UpsellCommissionPayout::factory()->paid()->create([
+        'teacher_user_id' => $teacher->id,
+    ]);
+    $payout->sessions()->create([
+        'class_session_id' => $session->id,
+        'paid_revenue' => 1000,
+        'commission_rate' => 10,
+        'commission_amount' => 60,
+    ]);
+
+    $this->actingAs($admin);
+
+    Volt::test('admin.upsell-dashboard')
+        ->assertSee('Paid Teacher')
+        ->assertSee('100.00')   // commission earned
+        ->assertSee('60.00')    // commission paid
+        ->assertSee('40.00');   // commission pending
 });

--- a/tests/Feature/ProductOrderReceiptDownloadTest.php
+++ b/tests/Feature/ProductOrderReceiptDownloadTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\ProductOrder;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('allows admin to download an order receipt PDF', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+    $order = ProductOrder::factory()->create(['payment_status' => 'paid']);
+
+    $response = $this->actingAs($admin)
+        ->get(route('admin.orders.receipt-pdf', $order));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toContain('application/pdf');
+});
+
+it('allows employee to download an order receipt PDF', function () {
+    $employee = User::factory()->create(['role' => 'employee']);
+    $order = ProductOrder::factory()->create(['payment_status' => 'paid']);
+
+    $response = $this->actingAs($employee)
+        ->get(route('admin.orders.receipt-pdf', $order));
+
+    $response->assertOk();
+});
+
+it('allows accountant to download an order receipt PDF', function () {
+    $accountant = User::factory()->create(['role' => 'accountant']);
+    $order = ProductOrder::factory()->create(['payment_status' => 'paid']);
+
+    $response = $this->actingAs($accountant)
+        ->get(route('admin.orders.receipt-pdf', $order));
+
+    $response->assertOk();
+});
+
+it('forbids non-admin/employee/accountant from downloading', function () {
+    $student = User::factory()->create(['role' => 'student']);
+    $order = ProductOrder::factory()->create();
+
+    $this->actingAs($student)
+        ->get(route('admin.orders.receipt-pdf', $order))
+        ->assertForbidden();
+});
+
+it('returns 404 for non-existent order', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+
+    $this->actingAs($admin)
+        ->get('/admin/product-orders/99999999/receipt-pdf')
+        ->assertNotFound();
+});
+
+it('requires authentication to download an order receipt PDF', function () {
+    $order = ProductOrder::factory()->create();
+
+    $this->get(route('admin.orders.receipt-pdf', $order))
+        ->assertRedirect(route('login'));
+});

--- a/tests/Unit/Services/CommissionPayoutServiceTest.php
+++ b/tests/Unit/Services/CommissionPayoutServiceTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ClassSession;
+use App\Models\FunnelOrder;
+use App\Models\ProductOrder;
+use App\Models\UpsellCommissionPayout;
+use App\Models\User;
+use App\Services\Upsell\CommissionPayoutService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+it('previews unpaid commission per teacher', function () {
+    $teacher = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $rows = app(CommissionPayoutService::class)->preview('2026-05-01', '2026-05-31');
+
+    expect($rows)->toHaveCount(1);
+    expect($rows->first()['commission_total'])->toBe(100.0);
+    expect($rows->first()['teacher_id'])->toBe($teacher->id);
+    expect($rows->first()['session_count'])->toBe(1);
+});
+
+it('splits commission across multiple teachers in preview', function () {
+    $teacherA = User::factory()->create();
+    $teacherB = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacherA->id, $teacherB->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $rows = app(CommissionPayoutService::class)->preview('2026-05-01', '2026-05-31')->keyBy('teacher_id');
+
+    expect($rows[$teacherA->id]['commission_total'])->toBe(50.0);
+    expect($rows[$teacherB->id]['commission_total'])->toBe(50.0);
+});
+
+it('excludes pending product orders from preview', function () {
+    $teacher = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $pending = ProductOrder::factory()->create(['payment_status' => 'pending']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $pending->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $rows = app(CommissionPayoutService::class)->preview('2026-05-01', '2026-05-31');
+
+    expect($rows)->toBeEmpty();
+});
+
+it('excludes sessions outside the date range', function () {
+    $teacher = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-04-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $rows = app(CommissionPayoutService::class)->preview('2026-05-01', '2026-05-31');
+
+    expect($rows)->toBeEmpty();
+});
+
+it('excludes sessions already in an existing payout', function () {
+    $teacher = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $existingPayout = UpsellCommissionPayout::factory()->create([
+        'teacher_user_id' => $teacher->id,
+        'status' => 'draft',
+    ]);
+    $existingPayout->sessions()->create([
+        'class_session_id' => $session->id,
+        'paid_revenue' => 1000,
+        'commission_rate' => 10,
+        'commission_amount' => 100,
+    ]);
+
+    $rows = app(CommissionPayoutService::class)->preview('2026-05-01', '2026-05-31');
+
+    expect($rows)->toBeEmpty();
+});
+
+it('creates a payout from session ids', function () {
+    $teacher = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $payout = app(CommissionPayoutService::class)->createPayout(
+        $teacher->id,
+        '2026-05-01',
+        '2026-05-31',
+        [$session->id]
+    );
+
+    expect($payout->status)->toBe('draft');
+    expect((float) $payout->total_commission)->toBe(100.0);
+    expect($payout->session_count)->toBe(1);
+    expect($payout->sessions()->count())->toBe(1);
+
+    $sessionRow = $payout->sessions()->first();
+    expect((float) $sessionRow->paid_revenue)->toBe(1000.0);
+    expect((float) $sessionRow->commission_rate)->toBe(10.0);
+    expect((float) $sessionRow->commission_amount)->toBe(100.0);
+});
+
+it('splits payout commission across multiple teachers when creating', function () {
+    $teacherA = User::factory()->create();
+    $teacherB = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacherA->id, $teacherB->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $payout = app(CommissionPayoutService::class)->createPayout(
+        $teacherA->id,
+        '2026-05-01',
+        '2026-05-31',
+        [$session->id]
+    );
+
+    expect((float) $payout->total_commission)->toBe(50.0);
+});
+
+it('refuses to create a payout for a teacher not on the session', function () {
+    $assignedTeacher = User::factory()->create();
+    $outsider = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$assignedTeacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    expect(fn () => app(CommissionPayoutService::class)->createPayout(
+        $outsider->id,
+        '2026-05-01',
+        '2026-05-31',
+        [$session->id]
+    ))->toThrow(InvalidArgumentException::class);
+});
+
+it('lock and markPaid follow state machine', function () {
+    $payout = UpsellCommissionPayout::factory()->create(['status' => 'draft']);
+
+    $payout->lock();
+    expect($payout->fresh()->status)->toBe('locked');
+    expect($payout->fresh()->locked_at)->not->toBeNull();
+
+    $accountant = User::factory()->create();
+    $payout->markPaid($accountant->id, 'TXN-12345');
+    expect($payout->fresh())
+        ->status->toBe('paid')
+        ->payment_reference->toBe('TXN-12345')
+        ->paid_by_user_id->toBe($accountant->id);
+});
+
+it('lock fails if not draft', function () {
+    $payout = UpsellCommissionPayout::factory()->locked()->create();
+    expect(fn () => $payout->lock())->toThrow(InvalidArgumentException::class);
+});
+
+it('markPaid fails if not locked', function () {
+    $payout = UpsellCommissionPayout::factory()->create(['status' => 'draft']);
+    $accountant = User::factory()->create();
+    expect(fn () => $payout->markPaid($accountant->id, 'TXN-001'))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('exposes status scopes', function () {
+    UpsellCommissionPayout::factory()->create(['status' => 'draft']);
+    UpsellCommissionPayout::factory()->locked()->create();
+    UpsellCommissionPayout::factory()->paid()->create();
+
+    expect(UpsellCommissionPayout::draft()->count())->toBe(1);
+    expect(UpsellCommissionPayout::locked()->count())->toBe(1);
+    expect(UpsellCommissionPayout::paid()->count())->toBe(1);
+});

--- a/tests/Unit/Services/UpsellPaidOrdersQueryTest.php
+++ b/tests/Unit/Services/UpsellPaidOrdersQueryTest.php
@@ -7,6 +7,7 @@ use App\Models\FunnelOrder;
 use App\Models\Product;
 use App\Models\ProductOrder;
 use App\Models\ProductOrderItem;
+use App\Models\UpsellCommissionPayout;
 use App\Models\User;
 use App\Services\Upsell\UpsellPaidOrdersQuery;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -229,6 +230,98 @@ it('skips funnel orders whose session has no upsell teachers in byTeacher', func
     $rows = app(UpsellPaidOrdersQuery::class)->byTeacher();
 
     expect($rows)->toHaveCount(0);
+});
+
+it('includes commission_paid from paid payouts in byTeacher', function () {
+    $teacher = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $payout = UpsellCommissionPayout::factory()->paid()->create([
+        'teacher_user_id' => $teacher->id,
+    ]);
+    $payout->sessions()->create([
+        'class_session_id' => $session->id,
+        'paid_revenue' => 1000,
+        'commission_rate' => 10,
+        'commission_amount' => 100,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)
+        ->forDateRange('2026-05-01', '2026-05-31')
+        ->byTeacher();
+
+    expect($rows)->toHaveCount(1);
+    expect((float) $rows->first()['commission_earned'])->toBe(100.0);
+    expect((float) $rows->first()['commission_paid'])->toBe(100.0);
+    expect((float) $rows->first()['commission_pending'])->toBe(0.0);
+});
+
+it('shows pending commission when no payout exists in byTeacher', function () {
+    $teacher = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)
+        ->forDateRange('2026-05-01', '2026-05-31')
+        ->byTeacher();
+
+    expect((float) $rows->first()['commission_earned'])->toBe(100.0);
+    expect((float) $rows->first()['commission_paid'])->toBe(0.0);
+    expect((float) $rows->first()['commission_pending'])->toBe(100.0);
+});
+
+it('does not count draft or locked payouts as paid in byTeacher', function () {
+    $teacher = User::factory()->create();
+    $session = ClassSession::factory()->create([
+        'upsell_funnel_ids' => [1],
+        'upsell_teacher_ids' => [$teacher->id],
+        'upsell_teacher_commission_rate' => 10,
+        'session_date' => '2026-05-15',
+    ]);
+    $paid = ProductOrder::factory()->create(['payment_status' => 'paid']);
+    FunnelOrder::factory()->create([
+        'class_session_id' => $session->id,
+        'product_order_id' => $paid->id,
+        'funnel_revenue' => 1000,
+    ]);
+
+    $draftPayout = UpsellCommissionPayout::factory()->draft()->create([
+        'teacher_user_id' => $teacher->id,
+    ]);
+    $draftPayout->sessions()->create([
+        'class_session_id' => $session->id,
+        'paid_revenue' => 1000,
+        'commission_rate' => 10,
+        'commission_amount' => 100,
+    ]);
+
+    $rows = app(UpsellPaidOrdersQuery::class)
+        ->forDateRange('2026-05-01', '2026-05-31')
+        ->byTeacher();
+
+    expect((float) $rows->first()['commission_paid'])->toBe(0.0);
+    expect((float) $rows->first()['commission_pending'])->toBe(100.0);
 });
 
 it('groups by product with line type from funnel order', function () {


### PR DESCRIPTION
## Summary

Phase C of the upsell system improvements. Wraps up the accountant-facing flows:

- **Per-order PDF receipt** — wires the existing `order-receipt-pdf.blade.php` template into a download route + button on order list and detail page.
- **`UpsellCommissionPayout` model + service** — mirrors the `LiveHostPayrollRun` pattern. State machine: draft → locked → paid. Per-teacher per-period payouts with bank reference tracking.
- **Accountant admin page** at `/admin/upsell-commissions` — preview unpaid commission by date range, create draft payouts per teacher, lock them, mark them paid with payment reference.
- **Reports wired** — by-teacher breakdown on dashboard and teacher detail page now show Commission Earned / Paid / Pending.

## Depends on

**Phase A PR #12 and Phase B PR #13 must merge first.** This branch is based off Phase B.

## What ships

- 2 new tables: `upsell_commission_payouts`, `upsell_commission_payout_sessions`
- 2 new models: `UpsellCommissionPayout`, `UpsellCommissionPayoutSession` (both with factories)
- 1 new service: `CommissionPayoutService` (preview + createPayout)
- 1 new route + controller: `admin.orders.receipt-pdf`
- 1 new Volt page: `admin.upsell-commission-payouts`
- 1 new Gate: `manageUpsellCommissions` (admin + accountant)
- New nav links: "Accounting" group for accountants, "Upsell Commission Payouts" link for admins

## Key design choices

- **Sessions can only appear in one payout.** Service unconditionally excludes any class_session that already has a payout row, regardless of status. Prevents double-payment.
- **Multi-teacher sessions split equally.** Same rule as Phase B reports. A session with 2 teachers and RM 100 commission produces 2 payout entries of RM 50 each.
- **Status transitions enforced.** `lock()` requires draft; `markPaid()` requires locked. Throws `InvalidArgumentException` on invalid transitions.
- **Paid commission filter scopes to session_date in range** — answers "what did the teacher earn during this period that has been paid out", not "what got paid out during this period" (different question).

## Test plan

- [ ] Log in as accountant. Go to `/admin/upsell-commissions`. Set period to last month. Click Load Preview — see unpaid commission per teacher.
- [ ] Click Create Payout for one teacher. Confirm draft appears in Drafts section.
- [ ] Click Lock — confirm it moves to Locked section.
- [ ] Click Mark Paid, enter `TXN-TEST-001`, confirm — confirm it moves to Paid History.
- [ ] Open `/admin/upsell-dashboard`. By-teacher table now shows Paid column with the amount.
- [ ] Open `/admin/teachers/{id}` for the same teacher — Upsell Performance section shows "Commission Paid" stat card.
- [ ] Download a PDF receipt for any order. Confirm it opens cleanly.
- [ ] Try `/admin/upsell-commissions` as a student — should 403.
- [ ] Try downloading a PDF receipt as a student — should 403.
- [ ] Run: `php artisan test --compact tests/Feature/ProductOrderReceiptDownloadTest.php tests/Unit/Services/CommissionPayoutServiceTest.php tests/Feature/Livewire/Admin/UpsellCommissionPayoutsTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)